### PR TITLE
remove .github/workflows/main.yml

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,14 +1,14 @@
 on:
-  push:
-    branches:
-    - main
-
+#  push:
+#    branches:
+#    - main
+#
 jobs:
-  contrib-readme-job:
-    runs-on: ubuntu-latest
-    name: A job to automate contrib in readme
-    steps:
-    - name: Contribute List
-      uses: akhilmhdh/contributors-readme-action@v2.3.6
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+#  contrib-readme-job:
+#    runs-on: ubuntu-latest
+#    name: A job to automate contrib in readme
+#    steps:
+#    - name: Contribute List
+#      uses: akhilmhdh/contributors-readme-action@v2.3.6
+#      env:
+#        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Changes proposed in this Pull Request

This pull request proposes to remove the main.yml workflow file from .github/workflows.

This is because this workflow file prompts the job that updates the contributors page. We do not need this functionality in OET pypsa-earth fork.

## Checklist

- [x] I consent to the release of this PR's code under the AGPLv3 license and non-code contributions under CC0-1.0 and CC-BY-4.0.
- [x] I tested my contribution locally and it seems to work fine.
- [ ] Code and workflow changes are sufficiently documented.
- [ ] Newly introduced dependencies are added to `envs/environment.yaml` and `doc/requirements.txt`.
- [ ] Changes in configuration options are added in all of `config.default.yaml` and `config.tutorial.yaml`.
- [ ] Add a test config or line additions to `test/` (note tests are changing the config.tutorial.yaml)
- [ ] Changes in configuration options are also documented in `doc/configtables/*.csv` and line references are adjusted in `doc/configuration.rst` and `doc/tutorial.rst`.
- [ ] A note for the release notes `doc/release_notes.rst` is amended in the format of previous release notes, including reference to the requested PR.
