### PR TITLE
Unify gadm download and layer

### DIFF
--- a/.github/workflows/ci-linux.yaml
+++ b/.github/workflows/ci-linux.yaml
@@ -32,7 +32,8 @@ jobs:
         shell: bash -l {0}
 
     steps:
-    - uses: actions/checkout@v3
+    - name: Checkout
+      uses: actions/checkout@v3
 
     - name: Setup Mambaforge
       uses: conda-incubator/setup-miniconda@v3

--- a/.github/workflows/ci-linux.yaml
+++ b/.github/workflows/ci-linux.yaml
@@ -32,7 +32,7 @@ jobs:
         shell: bash -l {0}
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 
     - name: Setup Mambaforge
       uses: conda-incubator/setup-miniconda@v2
@@ -43,7 +43,7 @@ jobs:
         use-mamba: true
 
     - name: Create environment cache
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       id: cache
       with:
         path: ${{ matrix.prefix }}

--- a/.github/workflows/ci-linux.yaml
+++ b/.github/workflows/ci-linux.yaml
@@ -35,7 +35,7 @@ jobs:
     - uses: actions/checkout@v3
 
     - name: Setup Mambaforge
-      uses: conda-incubator/setup-miniconda@v2
+      uses: conda-incubator/setup-miniconda@v3
       with:
         miniforge-variant: Mambaforge
         miniforge-version: latest

--- a/.github/workflows/ci-mac.yaml
+++ b/.github/workflows/ci-mac.yaml
@@ -37,7 +37,7 @@ jobs:
     #     echo -e "- glpk\n- ipopt<3.13.3" >> envs/environment.yaml
 
     - name: Setup Mambaforge
-      uses: conda-incubator/setup-miniconda@v2
+      uses: conda-incubator/setup-miniconda@v3
       with:
         miniforge-variant: Mambaforge
         miniforge-version: latest

--- a/.github/workflows/ci-mac.yaml
+++ b/.github/workflows/ci-mac.yaml
@@ -30,7 +30,7 @@ jobs:
         shell: bash -l {0}
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 
     # - name: Add solver to environment
     #   run: |
@@ -45,7 +45,7 @@ jobs:
         use-mamba: true
 
     - name: Create environment cache
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       id: cache
       with:
         path: ${{ matrix.prefix }}

--- a/.github/workflows/ci-mac.yaml
+++ b/.github/workflows/ci-mac.yaml
@@ -50,11 +50,11 @@ jobs:
       id: cache
       with:
         path: ${{ matrix.prefix }}
-        key: ${{ matrix.label }}-conda-${{ hashFiles('envs/environment.yaml') }}-${{ env.DATE }}-${{ env.CACHE_NUMBER }}
+        key: ${{ matrix.label }}-conda-${{ hashFiles('envs/environment.mac.yaml') }}-${{ env.DATE }}-${{ env.CACHE_NUMBER }}
 
     - name: Update environment due to outdated or unavailable cache
       if: steps.cache.outputs.cache-hit != 'true'
-      run: mamba env update -n pypsa-earth -f envs/environment.yaml
+      run: mamba env update -n pypsa-earth -f envs/environment.mac.yaml
 
     - name: Conda list
       run: |

--- a/.github/workflows/ci-mac.yaml
+++ b/.github/workflows/ci-mac.yaml
@@ -30,7 +30,8 @@ jobs:
         shell: bash -l {0}
 
     steps:
-    - uses: actions/checkout@v3
+    - name: Checkout
+      uses: actions/checkout@v3
 
     # - name: Add solver to environment
     #   run: |

--- a/.github/workflows/ci-windows.yaml
+++ b/.github/workflows/ci-windows.yaml
@@ -37,7 +37,7 @@ jobs:
     #     echo -e "- glpk\n- ipopt<3.13.3" >> envs/environment.yaml
 
     - name: Setup Mambaforge
-      uses: conda-incubator/setup-miniconda@v2
+      uses: conda-incubator/setup-miniconda@v3
       with:
         miniforge-variant: Mambaforge
         miniforge-version: latest

--- a/.github/workflows/ci-windows.yaml
+++ b/.github/workflows/ci-windows.yaml
@@ -30,7 +30,7 @@ jobs:
         shell: bash -l {0}
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 
     # - name: Add solver to environment
     #   run: |
@@ -45,7 +45,7 @@ jobs:
         use-mamba: true
 
     - name: Create environment cache
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       id: cache
       with:
         path: ${{ matrix.prefix }}

--- a/.github/workflows/ci-windows.yaml
+++ b/.github/workflows/ci-windows.yaml
@@ -30,7 +30,8 @@ jobs:
         shell: bash -l {0}
 
     steps:
-    - uses: actions/checkout@v3
+    - name: Checkout
+      uses: actions/checkout@v3
 
     # - name: Add solver to environment
     #   run: |

--- a/config.default.yaml
+++ b/config.default.yaml
@@ -94,6 +94,10 @@ build_shape_options:
   worldpop_method: "standard"  # "standard" pulls from web 1kmx1km raster, "api" pulls from API 100mx100m raster, false (not "false") no pop addition to shape which is useful when generating only cutout
   gdp_method: "standard"  # "standard" pulls from web 1x1km raster, false (not "false") no gdp addition to shape which useful when generating only cutout
   contended_flag: "set_by_country" # "set_by_country" assigns the contended areas to the countries according to the GADM database, "drop" drops these contended areas from the model
+  gadm_file_prefix_v36: "gadm36_"
+  gadm_file_prefix_v41: "gadm41_"
+  gadm_url_prefix_v36: "https://geodata.ucdavis.edu/gadm/gadm3.6/gpkg/"
+  gadm_url_prefix_v41: "https://geodata.ucdavis.edu/gadm/gadm4.1/gpkg/"
 
 clean_osm_data_options:  # osm = OpenStreetMap
   names_by_shapes: true  # Set the country name based on the extended country shapes

--- a/config.default.yaml
+++ b/config.default.yaml
@@ -94,8 +94,8 @@ build_shape_options:
   worldpop_method: "standard"  # "standard" pulls from web 1kmx1km raster, "api" pulls from API 100mx100m raster, false (not "false") no pop addition to shape which is useful when generating only cutout
   gdp_method: "standard"  # "standard" pulls from web 1x1km raster, false (not "false") no gdp addition to shape which useful when generating only cutout
   contended_flag: "set_by_country" # "set_by_country" assigns the contended areas to the countries according to the GADM database, "drop" drops these contended areas from the model
-  gadm_file_prefix_v41: "gadm41_"
-  gadm_url_prefix_v41: "https://geodata.ucdavis.edu/gadm/gadm4.1/gpkg/"
+  gadm_file_prefix: "gadm41_"
+  gadm_url_prefix: "https://geodata.ucdavis.edu/gadm/gadm4.1/gpkg/"
 
 clean_osm_data_options:  # osm = OpenStreetMap
   names_by_shapes: true  # Set the country name based on the extended country shapes

--- a/config.default.yaml
+++ b/config.default.yaml
@@ -94,9 +94,7 @@ build_shape_options:
   worldpop_method: "standard"  # "standard" pulls from web 1kmx1km raster, "api" pulls from API 100mx100m raster, false (not "false") no pop addition to shape which is useful when generating only cutout
   gdp_method: "standard"  # "standard" pulls from web 1x1km raster, false (not "false") no gdp addition to shape which useful when generating only cutout
   contended_flag: "set_by_country" # "set_by_country" assigns the contended areas to the countries according to the GADM database, "drop" drops these contended areas from the model
-  gadm_file_prefix_v36: "gadm36_"
   gadm_file_prefix_v41: "gadm41_"
-  gadm_url_prefix_v36: "https://geodata.ucdavis.edu/gadm/gadm3.6/gpkg/"
   gadm_url_prefix_v41: "https://geodata.ucdavis.edu/gadm/gadm4.1/gpkg/"
 
 clean_osm_data_options:  # osm = OpenStreetMap

--- a/config.tutorial.yaml
+++ b/config.tutorial.yaml
@@ -108,6 +108,10 @@ build_shape_options:
   worldpop_method: "standard"  # "standard" pulls from web 1kmx1km raster, "api" pulls from API 100mx100m raster, false (not "false") no pop addition to shape which is useful when generating only cutout
   gdp_method: "standard"  # "standard" pulls from web 1x1km raster, false (not "false") no gdp addition to shape which useful when generating only cutout
   contended_flag: "set_by_country" # "set_by_country" assigns the contended areas to the countries according to the GADM database, "drop" drops these contended areas from the model
+  gadm_file_prefix_v36: "gadm36_"
+  gadm_file_prefix_v41: "gadm41_"
+  gadm_url_prefix_v36: "https://geodata.ucdavis.edu/gadm/gadm3.6/gpkg/"
+  gadm_url_prefix_v41: "https://geodata.ucdavis.edu/gadm/gadm4.1/gpkg/"
 
 clean_osm_data_options:
   names_by_shapes: true  # Set the country name based on the extended country shapes

--- a/config.tutorial.yaml
+++ b/config.tutorial.yaml
@@ -19,7 +19,7 @@ countries: ["NG", "BJ"]
   #["NG"]  # Nigeria
   #["NE"]  # Niger
   #["SL"]  # Sierra Leone
-  #["MA"]  # Morroco
+  #["MA"]  # Morocco
   #["ZA"]  # South Africa
 
 enable:

--- a/config.tutorial.yaml
+++ b/config.tutorial.yaml
@@ -108,9 +108,7 @@ build_shape_options:
   worldpop_method: "standard"  # "standard" pulls from web 1kmx1km raster, "api" pulls from API 100mx100m raster, false (not "false") no pop addition to shape which is useful when generating only cutout
   gdp_method: "standard"  # "standard" pulls from web 1x1km raster, false (not "false") no gdp addition to shape which useful when generating only cutout
   contended_flag: "set_by_country" # "set_by_country" assigns the contended areas to the countries according to the GADM database, "drop" drops these contended areas from the model
-  gadm_file_prefix_v36: "gadm36_"
   gadm_file_prefix_v41: "gadm41_"
-  gadm_url_prefix_v36: "https://geodata.ucdavis.edu/gadm/gadm3.6/gpkg/"
   gadm_url_prefix_v41: "https://geodata.ucdavis.edu/gadm/gadm4.1/gpkg/"
 
 clean_osm_data_options:

--- a/config.tutorial.yaml
+++ b/config.tutorial.yaml
@@ -108,8 +108,8 @@ build_shape_options:
   worldpop_method: "standard"  # "standard" pulls from web 1kmx1km raster, "api" pulls from API 100mx100m raster, false (not "false") no pop addition to shape which is useful when generating only cutout
   gdp_method: "standard"  # "standard" pulls from web 1x1km raster, false (not "false") no gdp addition to shape which useful when generating only cutout
   contended_flag: "set_by_country" # "set_by_country" assigns the contended areas to the countries according to the GADM database, "drop" drops these contended areas from the model
-  gadm_file_prefix_v41: "gadm41_"
-  gadm_url_prefix_v41: "https://geodata.ucdavis.edu/gadm/gadm4.1/gpkg/"
+  gadm_file_prefix: "gadm41_"
+  gadm_url_prefix: "https://geodata.ucdavis.edu/gadm/gadm4.1/gpkg/"
 
 clean_osm_data_options:
   names_by_shapes: true  # Set the country name based on the extended country shapes

--- a/envs/environment.mac.yaml
+++ b/envs/environment.mac.yaml
@@ -1,0 +1,87 @@
+# SPDX-FileCopyrightText:  PyPSA-Earth and PyPSA-Eur Authors
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+name: pypsa-earth
+channels:
+- conda-forge
+- bioconda
+- gurobi
+dependencies:
+- python>=3.8
+- pip
+- mamba   # esp for windows build
+
+- pypsa>=0.24, <0.25
+# - atlite>=0.2.4  # until https://github.com/PyPSA/atlite/issues/244 is not merged
+- dask
+- powerplantmatching>=0.5.7
+- earth-osm>=2.1
+- atlite
+
+  # Dependencies of the workflow itself
+- xlrd
+- openpyxl
+- seaborn
+- snakemake-minimal<8
+- memory_profiler
+- ruamel.yaml<=0.17.26
+- pytables
+- lxml
+- numpy
+- pandas
+- geopandas>=0.11.0, <=0.14.3
+- fiona!=1.8.22
+- xarray>=2023.11.0, <2023.12.0
+- netcdf4
+- networkx
+- scipy
+- pydoe2
+- shapely!=2.0.4
+- pre-commit
+- pyomo
+- matplotlib<=3.5.2
+- reverse-geocode
+- country_converter
+- pyogrio
+- numba
+- py7zr
+
+  # Keep in conda environment when calling ipython
+- ipython
+  # Jupyter notebook requirement
+- ipykernel
+- jupyterlab
+
+  # GIS dependencies:
+- cartopy
+- descartes
+- rasterio!=1.2.10
+- rioxarray
+
+ # Plotting
+- geoviews
+- hvplot
+- graphviz
+- contextily
+- graphviz
+
+  # PyPSA-Eur-Sec Dependencies
+- geopy
+- tqdm
+- pytz
+- country_converter
+
+  # Cloud download
+# - googledrivedownloader  # Commented until https://github.com/ndrplz/google-drive-downloader/pull/28 is merged: PR installed using pip
+
+# Default solver for tests (required for CI)
+- glpk
+- ipopt
+- gurobi
+
+- pip:
+  - git+https://github.com/davide-f/google-drive-downloader@master  # google drive with fix for virus scan
+  - git+https://github.com/FRESNA/vresutils@master  # until new pip release > 0.3.1 (strictly)
+  - tsam>=1.1.0
+  - chaospy  # lastest version only available on pip

--- a/envs/environment.yaml
+++ b/envs/environment.yaml
@@ -77,7 +77,7 @@ dependencies:
 
 # Default solver for tests (required for CI)
 - glpk
-- ipopt<3.13.3
+- ipopt
 - gurobi
 
 - pip:

--- a/envs/environment.yaml
+++ b/envs/environment.yaml
@@ -77,7 +77,7 @@ dependencies:
 
 # Default solver for tests (required for CI)
 - glpk
-- ipopt
+- ipopt<3.13.3
 - gurobi
 
 - pip:

--- a/scripts/_helpers.py
+++ b/scripts/_helpers.py
@@ -987,17 +987,17 @@ def download_gadm(
 
     gadm_filename = get_gadm_filename(country_code, file_prefix)
     gadm_url = get_gadm_url(gadm_url_prefix, gadm_filename, use_zip_file)
-    gadm_input_file = str(
-        get_path(
-            get_current_directory_path(),
-            *gadm_input_file_args,
-            gadm_filename,
-            gadm_filename,
-        )
+    gadm_input_file = get_path(
+        get_current_directory_path(),
+        *gadm_input_file_args,
+        gadm_filename,
+        gadm_filename,
     )
 
-    gadm_input_file_gpkg = gadm_input_file + ".gpkg"  # Input filepath gpkg
-    gadm_input_file_zip = gadm_input_file + ".zip"  # Input filepath zip"
+    gadm_input_file_gpkg = get_path(
+        str(gadm_input_file) + ".gpkg"
+    )  # Input filepath gpkg
+    gadm_input_file_zip = get_path(str(gadm_input_file) + ".zip")  # Input filepath zip"
 
     if not pathlib.Path(gadm_input_file_gpkg).exists() or update is True:
         if out_logging:
@@ -1333,59 +1333,6 @@ def safe_divide(numerator, denominator):
             f"Division by zero: {numerator} / {denominator}, returning NaN."
         )
         return np.nan
-
-
-def download_gadm_build_shapes(country_code, update=False, out_logging=False):
-    """
-    Download gpkg file from GADM for a given country code.
-
-    Parameters
-    ----------
-    country_code : str
-        Two letter country codes of the downloaded files
-    update : bool
-        Update = true, forces re-download of files
-
-    Returns
-    -------
-    gpkg file per country
-    """
-    GADM_filename = get_gadm_filename(country_code)
-    GADM_url = f"https://geodata.ucdavis.edu/gadm/gadm4.1/gpkg/{GADM_filename}.gpkg"
-
-    GADM_inputfile_gpkg = get_path(
-        get_current_directory_path(),
-        "data",
-        "gadm",
-        GADM_filename,
-        GADM_filename + ".gpkg",
-    )  # Input filepath gpkg
-
-    if not pathlib.Path(GADM_inputfile_gpkg).exists() or update is True:
-        if out_logging:
-            logger.warning(
-                f"Stage 5 of 5: {GADM_filename} of country {two_digits_2_name_country(country_code)} does not exist, downloading to {GADM_inputfile_gpkg}"
-            )
-        #  create data/osm directory
-        build_directory(GADM_inputfile_gpkg)
-
-        try:
-            r = requests.get(GADM_url, stream=True, timeout=300)
-        except (requests.exceptions.ConnectionError, requests.exceptions.Timeout):
-            raise Exception(
-                f"GADM server is down at {GADM_url}. Data needed for building shapes can't be extracted.\n\r"
-            )
-        except Exception as exception:
-            raise Exception(
-                f"An error happened when trying to load GADM data by {GADM_url}.\n\r"
-                + str(exception)
-                + "\n\r"
-            )
-        else:
-            with open(GADM_inputfile_gpkg, "wb") as f:
-                shutil.copyfileobj(r.raw, f)
-
-    return GADM_inputfile_gpkg, GADM_filename
 
 
 def download_GADM_helpers_pes(country_code, update=False, out_logging=False):

--- a/scripts/_helpers.py
+++ b/scripts/_helpers.py
@@ -938,14 +938,11 @@ def get_gadm_filename(country_code, file_prefix="gadm41_"):
         return file_prefix + two_2_three_digits_country(country_code)
 
 
-def get_gadm_url(gadm_url_prefix, gadm_filename, use_zip_file=False):
+def get_gadm_url(gadm_url_prefix, gadm_filename):
     """
     Function to get the gadm url given a gadm filename.
     """
-    if use_zip_file:
-        return gadm_url_prefix + gadm_filename + "_gpkg.zip"
-    else:
-        return gadm_url_prefix + gadm_filename + ".gpkg"
+    return gadm_url_prefix + gadm_filename + ".gpkg"
 
 
 def download_gadm(

--- a/scripts/_helpers.py
+++ b/scripts/_helpers.py
@@ -910,7 +910,7 @@ def cycling_shift(df, steps=1):
     return df
 
 
-def get_gadm_country_code(country_code):
+def get_gadm_filename(country_code, file_prefix="gadm41_"):
     """
     Function to get three digits country code for GADM.
     """
@@ -933,16 +933,9 @@ def get_gadm_country_code(country_code):
     }
 
     if country_code in special_codes_gadm:
-        return special_codes_gadm[country_code]
+        return file_prefix + special_codes_gadm[country_code]
     else:
-        return two_2_three_digits_country(country_code)
-
-
-def get_gadm_filename(gadm_country_code, file_prefix="gadm41_"):
-    """
-    Function to get the gadm filename given the country code.
-    """
-    return file_prefix + gadm_country_code
+        return file_prefix + two_2_three_digits_country(country_code)
 
 
 def get_gadm_url(gadm_url_prefix, gadm_filename, use_zip_file=False):
@@ -988,8 +981,7 @@ def download_gadm(
 
     _logger = logging.getLogger(__name__)
 
-    gadm_country_code = get_gadm_country_code(country_code)
-    gadm_filename = get_gadm_filename(gadm_country_code, file_prefix)
+    gadm_filename = get_gadm_filename(country_code, file_prefix)
     gadm_url = get_gadm_url(gadm_url_prefix, gadm_filename)
     gadm_input_file = get_path(
         get_current_directory_path(),

--- a/scripts/_helpers.py
+++ b/scripts/_helpers.py
@@ -1132,6 +1132,22 @@ def get_gadm_layer(
         Layer to consider in the format GID_{layer_id}.
         When the requested layer_id is greater than the last available layer, then the last layer is selected.
         When a negative value is requested, then, the last layer is requested
+    geo_crs: str
+        General geographic projection
+    file_prefix : str
+        file prefix string
+    gadm_url_prefix : str
+        gadm url prefix
+    gadm_input_file_args: list[str]
+        gadm input file arguments list
+    contended_flag : str
+        contended areas
+    update : bool
+        Update = true, forces re-download of files
+    out_logging : bool
+        out_logging = true, enables output logging
+    use_zip_file : bool
+        use_zip_file = true, enables output logging
     """
     # initialization of the list of geo dataframes
     geo_df_list = []
@@ -1200,7 +1216,15 @@ def locate_bus(
     coords,
     co,
     gadm_level,
+    geo_crs,
+    file_prefix,
+    gadm_url_prefix,
+    gadm_input_file_args,
+    contended_flag,
     path_to_gadm=None,
+    update=False,
+    out_logging=False,
+    use_zip_file=True,
     gadm_clustering=False,
 ):
     """
@@ -1213,6 +1237,30 @@ def locate_bus(
         dataseries with 2 rows x & y representing the longitude and latitude
     co: string (code for country where coords are MA Morocco)
         code of the countries where the coordinates are
+    gadm_level : int
+        Layer to consider in the format GID_{layer_id}.
+        When the requested layer_id is greater than the last available layer, then the last layer is selected.
+        When a negative value is requested, then, the last layer is requested
+    geo_crs : str
+        General geographic projection
+    file_prefix : str
+        file prefix string
+    gadm_url_prefix: str
+        gadm url prefix
+    gadm_input_file_args: list[str]
+        gadm input file arguments list
+    contended_flag : str
+        contended areas
+    path_to_gadm : str
+        path to gadm
+    update : bool
+        Update = true, forces re-download of files
+    out_logging : bool
+        out_logging = true, enables output logging
+    use_zip_file : bool
+        use_zip_file = true, enables output logging
+    gadm_clustering : bool
+        gadm_cluster = true, to enable clustering
     """
     col = "name"
     if not gadm_clustering:
@@ -1230,7 +1278,18 @@ def locate_bus(
                         lambda name: three_2_two_digits_country(name[:3]) + name[3:]
                     )
         else:
-            gdf = get_gadm_layer(co, gadm_level)
+            gdf = get_gadm_layer(
+                co,
+                gadm_level,
+                geo_crs,
+                file_prefix,
+                gadm_url_prefix,
+                gadm_input_file_args,
+                contended_flag,
+                update,
+                out_logging,
+                use_zip_file,
+            )
             col = "GID_{}".format(gadm_level)
 
         # gdf.set_index("GADM_ID", inplace=True)

--- a/scripts/_helpers.py
+++ b/scripts/_helpers.py
@@ -911,23 +911,27 @@ def cycling_shift(df, steps=1):
     return df
 
 
-def download_gadm(country_code, update=False, out_logging=False):
+def download_gadm(country_code, file_prefix, update=False, out_logging=False):
     """
     Download gpkg file from GADM for a given country code.
 
     Parameters
     ----------
     country_code : str
-        Two letter country codes of the downloaded files
+        2-digit country name of the downloaded files
+    file_prefix : str
+        file prefix string
     update : bool
         Update = true, forces re-download of files
+    out_logging : bool
+        out_logging = true, enables output logging
 
     Returns
     -------
     gpkg file per country
     """
 
-    gadm_filename = f"gadm36_{two_2_three_digits_country(country_code)}"
+    gadm_filename = get_gadm_filename(country_code, file_prefix)
     gadm_url = f"https://biogeo.ucdavis.edu/data/gadm3.6/gpkg/{gadm_filename}_gpkg.zip"
     _logger = logging.getLogger(__name__)
     gadm_input_file_zip = get_path(
@@ -985,7 +989,9 @@ def get_gadm_layer(country_list, layer_id, update=False, outlogging=False):
 
     for country_code in country_list:
         # download file gpkg
-        file_gpkg, name_file = download_gadm(country_code, update, outlogging)
+        file_gpkg, name_file = download_gadm(
+            country_code, file_prefix, update, outlogging
+        )
 
         # get layers of a geopackage
         list_layers = fiona.listlayers(file_gpkg)
@@ -1257,3 +1263,31 @@ def safe_divide(numerator, denominator):
             f"Division by zero: {numerator} / {denominator}, returning NaN."
         )
         return np.nan
+
+
+def get_gadm_filename(country_code, file_prefix="gadm41_"):
+    """
+    Function to get the gadm filename given the country code.
+    """
+    special_codes_gadm = {
+        "XK": "XKO",  # kosovo
+        "CP": "XCL",  # clipperton island
+        "SX": "MAF",  # saint-martin
+        "TF": "ATF",  # french southern territories
+        "AX": "ALA",  # aland
+        "IO": "IOT",  # british indian ocean territory
+        "CC": "CCK",  # cocos island
+        "NF": "NFK",  # norfolk
+        "PN": "PCN",  # pitcairn islands
+        "JE": "JEY",  # jersey
+        "XS": "XSP",  # spratly islands
+        "GG": "GGY",  # guernsey
+        "UM": "UMI",  # United States minor outlying islands
+        "SJ": "SJM",  # svalbard
+        "CX": "CXR",  # Christmas island
+    }
+
+    if country_code in special_codes_gadm:
+        return file_prefix + special_codes_gadm[country_code]
+    else:
+        return file_prefix + two_2_three_digits_country(country_code)

--- a/scripts/_helpers.py
+++ b/scripts/_helpers.py
@@ -997,7 +997,7 @@ def download_gadm(
     gadm_input_file_gpkg = get_path(
         str(gadm_input_file) + ".gpkg"
     )  # Input filepath gpkg
-    gadm_input_file_zip = get_path(str(gadm_input_file) + ".zip")  # Input filepath zip"
+    gadm_input_file_zip = get_path(str(gadm_input_file) + ".zip")  # Input filepath zip
 
     if not pathlib.Path(gadm_input_file_gpkg).exists() or update is True:
         if out_logging:
@@ -1333,58 +1333,3 @@ def safe_divide(numerator, denominator):
             f"Division by zero: {numerator} / {denominator}, returning NaN."
         )
         return np.nan
-
-
-def download_GADM_helpers_pes(country_code, update=False, out_logging=False):
-    """
-    Download gpkg file from GADM for a given country code.
-
-    Parameters
-    ----------
-    country_code : str
-        Two letter country codes of the downloaded files
-    update : bool
-        Update = true, forces re-download of files
-
-    Returns
-    -------
-    gpkg file per country
-    """
-
-    GADM_filename = f"gadm36_{two_2_three_digits_country(country_code)}"
-    GADM_url = f"https://biogeo.ucdavis.edu/data/gadm3.6/gpkg/{GADM_filename}_gpkg.zip"
-    _logger = logging.getLogger(__name__)
-    GADM_inputfile_zip = os.path.join(
-        os.getcwd(),
-        "data",
-        "raw",
-        "gadm",
-        GADM_filename,
-        GADM_filename + ".zip",
-    )  # Input filepath zip
-
-    GADM_inputfile_gpkg = os.path.join(
-        os.getcwd(),
-        "data",
-        "raw",
-        "gadm",
-        GADM_filename,
-        GADM_filename + ".gpkg",
-    )  # Input filepath gpkg
-
-    if not os.path.exists(GADM_inputfile_gpkg) or update is True:
-        if out_logging:
-            _logger.warning(
-                f"Stage 4/4: {GADM_filename} of country {two_digits_2_name_country(country_code)} does not exist, downloading to {GADM_inputfile_zip}"
-            )
-        #  create data/osm directory
-        os.makedirs(os.path.dirname(GADM_inputfile_zip), exist_ok=True)
-
-        with requests.get(GADM_url, stream=True) as r:
-            with open(GADM_inputfile_zip, "wb") as f:
-                shutil.copyfileobj(r.raw, f)
-
-        with zipfile.ZipFile(GADM_inputfile_zip, "r") as zip_ref:
-            zip_ref.extractall(os.path.dirname(GADM_inputfile_zip))
-
-    return GADM_inputfile_gpkg, GADM_filename

--- a/scripts/build_shapes.py
+++ b/scripts/build_shapes.py
@@ -11,7 +11,6 @@ import shutil
 from itertools import takewhile
 from operator import attrgetter
 
-import fiona
 import geopandas as gpd
 import numpy as np
 import pandas as pd
@@ -24,14 +23,12 @@ from _helpers import (
     configure_logging,
     create_logger,
     get_current_directory_path,
-    get_gadm_filename,
     get_gadm_layer,
     get_path,
     mock_snakemake,
     sets_path_to_root,
     three_2_two_digits_country,
     two_2_three_digits_country,
-    two_digits_2_name_country,
 )
 from numba import njit
 from numba.core import types
@@ -78,7 +75,6 @@ def countries(
     contended_flag,
     update,
     out_logging,
-    use_zip_file=False,
 ):
     "Create country shapes"
 
@@ -96,7 +92,6 @@ def countries(
         contended_flag,
         update,
         out_logging,
-        use_zip_file,
     )
 
     # select and rename columns
@@ -1137,7 +1132,7 @@ def gadm(
             name_file_nc="GDP_PPP_1990_2015_5arcmin_v2.nc",
         )
 
-    # renaming 3 letter to 2 letter ISO code before saving GADM file
+    # renaming three-letter to two-letter ISO code before saving GADM file
     # In the case of a contested territory in the form 'Z00.00_0', save 'AA.00_0'
     # Include bugfix for the case of 'XXX00_0' where the "." is missing, such as for Ghana
     df_gadm["GADM_ID"] = df_gadm["country"] + df_gadm["GADM_ID"].str[3:].apply(
@@ -1191,7 +1186,6 @@ if __name__ == "__main__":
         contended_flag,
         update,
         out_logging,
-        use_zip_file=False,
     )
     country_shapes.to_file(snakemake.output.country_shapes)
 
@@ -1221,6 +1215,5 @@ if __name__ == "__main__":
         out_logging,
         year,
         nprocesses=nprocesses,
-        use_zip_file=False,
     )
     save_to_geojson(gadm_shapes, out.gadm_shapes)

--- a/scripts/build_shapes.py
+++ b/scripts/build_shapes.py
@@ -1170,8 +1170,8 @@ if __name__ == "__main__":
     contended_flag = snakemake.params.build_shape_options["contended_flag"]
     worldpop_method = snakemake.params.build_shape_options["worldpop_method"]
     gdp_method = snakemake.params.build_shape_options["gdp_method"]
-    file_prefix = snakemake.params.build_shape_options["gadm_file_prefix_v41"]
-    gadm_url_prefix = snakemake.params.build_shape_options["gadm_url_prefix_v41"]
+    file_prefix = snakemake.params.build_shape_options["gadm_file_prefix"]
+    gadm_url_prefix = snakemake.params.build_shape_options["gadm_url_prefix"]
     gadm_input_file_args = ["data", "gadm"]
 
     country_shapes = countries(

--- a/scripts/build_shapes.py
+++ b/scripts/build_shapes.py
@@ -24,6 +24,7 @@ from _helpers import (
     configure_logging,
     create_logger,
     get_current_directory_path,
+    get_gadm_filename,
     get_path,
     mock_snakemake,
     sets_path_to_root,
@@ -47,34 +48,6 @@ sets_path_to_root("pypsa-earth")
 logger = create_logger(__name__)
 
 
-def get_GADM_filename(country_code):
-    """
-    Function to get the GADM filename given the country code.
-    """
-    special_codes_GADM = {
-        "XK": "XKO",  # kosovo
-        "CP": "XCL",  # clipperton island
-        "SX": "MAF",  # sint maartin
-        "TF": "ATF",  # french southern territories
-        "AX": "ALA",  # aland
-        "IO": "IOT",  # british indian ocean territory
-        "CC": "CCK",  # cocos island
-        "NF": "NFK",  # norfolk
-        "PN": "PCN",  # pitcairn islands
-        "JE": "JEY",  # jersey
-        "XS": "XSP",  # spratly
-        "GG": "GGY",  # guernsey
-        "UM": "UMI",  # united states minor outlying islands
-        "SJ": "SJM",  # svalbard
-        "CX": "CXR",  # Christmas island
-    }
-
-    if country_code in special_codes_GADM:
-        return f"gadm41_{special_codes_GADM[country_code]}"
-    else:
-        return f"gadm41_{two_2_three_digits_country(country_code)}"
-
-
 def download_GADM(country_code, update=False, out_logging=False):
     """
     Download gpkg file from GADM for a given country code.
@@ -90,7 +63,7 @@ def download_GADM(country_code, update=False, out_logging=False):
     -------
     gpkg file per country
     """
-    GADM_filename = get_GADM_filename(country_code)
+    GADM_filename = get_gadm_filename(country_code)
     GADM_url = f"https://geodata.ucdavis.edu/gadm/gadm4.1/gpkg/{GADM_filename}.gpkg"
 
     GADM_inputfile_gpkg = get_path(

--- a/scripts/build_shapes.py
+++ b/scripts/build_shapes.py
@@ -1177,9 +1177,8 @@ if __name__ == "__main__":
     contended_flag = snakemake.params.build_shape_options["contended_flag"]
     worldpop_method = snakemake.params.build_shape_options["worldpop_method"]
     gdp_method = snakemake.params.build_shape_options["gdp_method"]
-
-    file_prefix = "gadm41_"
-    gadm_url_prefix = "https://geodata.ucdavis.edu/gadm/gadm4.1/gpkg/"
+    file_prefix = snakemake.params.build_shape_options["gadm_file_prefix_v41"]
+    gadm_url_prefix = snakemake.params.build_shape_options["gadm_url_prefix_v41"]
     gadm_input_file_args = ["data", "gadm"]
 
     country_shapes = countries(

--- a/scripts/build_shapes.py
+++ b/scripts/build_shapes.py
@@ -1078,7 +1078,6 @@ def gadm(
     out_logging=False,
     year=2020,
     nprocesses=None,
-    use_zip_file=False,
 ):
     if out_logging:
         logger.info("Stage 3 of 5: Creation GADM GeoDataFrame")
@@ -1094,7 +1093,6 @@ def gadm(
         contended_flag,
         update,
         out_logging,
-        use_zip_file,
     )
 
     # select and rename columns

--- a/scripts/prepare_network.py
+++ b/scripts/prepare_network.py
@@ -103,9 +103,11 @@ def download_emission_data():
             )
         pathlib.Path(file_path).unlink(missing_ok=True)
         return "v60_CO2_excl_short-cycle_org_C_1970_2018.xls"
-    except:
-        logger.error(f"Failed download resource from '{url}'.")
-        return False
+    except requests.exceptions.RequestException as e:
+        logger.error(
+            f"Failed download resource from '{url}' with exception message '{e}'."
+        )
+        raise SystemExit(e)
 
 
 def emission_extractor(filename, emission_year, country_names):
@@ -120,7 +122,7 @@ def emission_extractor(filename, emission_year, country_names):
     emission_year : int
         Year of CO2 emissions
     country_names : numpy.ndarray
-        Two letter country codes of analysed countries.
+        Two-letter country codes of analysed countries.
 
     Returns
     -------
@@ -128,7 +130,7 @@ def emission_extractor(filename, emission_year, country_names):
     """
 
     # data reading process
-    data_path = get_path(get_current_directory_path(), "data", str(filename))
+    data_path = get_path(get_current_directory_path(), "data", filename)
     df = pd.read_excel(data_path, sheet_name="v6.0_EM_CO2_fossil_IPCC1996", skiprows=8)
     df.columns = df.iloc[0]
     df = df.set_index("Country_code_A3")
@@ -192,7 +194,7 @@ def set_line_s_max_pu(n, s_max_pu):
     logger.info(f"N-1 security margin of lines set to {s_max_pu}")
 
 
-def set_transmission_limit(n, ll_type, factor, costs, Nyears=1):
+def set_transmission_limit(n, ll_type, factor, costs):
     links_dc_b = n.links.carrier == "DC" if not n.links.empty else pd.Series()
 
     _lines_s_nom = (
@@ -430,7 +432,7 @@ if __name__ == "__main__":
                 break
 
     ll_type, factor = snakemake.wildcards.ll[0], snakemake.wildcards.ll[1:]
-    set_transmission_limit(n, ll_type, factor, costs, Nyears)
+    set_transmission_limit(n, ll_type, factor, costs)
 
     set_line_nom_max(
         n,

--- a/scripts/prepare_network.py
+++ b/scripts/prepare_network.py
@@ -128,8 +128,8 @@ def emission_extractor(filename, emission_year, country_names):
     """
 
     # data reading process
-    datapath = get_path(get_current_directory_path(), "data", filename)
-    df = pd.read_excel(datapath, sheet_name="v6.0_EM_CO2_fossil_IPCC1996", skiprows=8)
+    data_path = get_path(get_current_directory_path(), "data", str(filename))
+    df = pd.read_excel(data_path, sheet_name="v6.0_EM_CO2_fossil_IPCC1996", skiprows=8)
     df.columns = df.iloc[0]
     df = df.set_index("Country_code_A3")
     df = df.loc[

--- a/scripts/retrieve_databundle_light.py
+++ b/scripts/retrieve_databundle_light.py
@@ -162,8 +162,10 @@ def download_and_unzip_zenodo(config, root_path, hot_run=True, disable_progress=
                 zipObj.extractall(path=destination)
             pathlib.Path(file_path).unlink(missing_ok=True)
             logger.info(f"Downloaded resource '{resource}' from cloud '{url}'.")
-        except:
-            logger.warning(f"Failed download resource '{resource}' from cloud '{url}'.")
+        except Exception as e:
+            logger.warning(
+                f"Failed download resource '{resource}' from cloud '{url}' with exception message '{e}'."
+            )
             return False
 
     return True
@@ -336,9 +338,9 @@ def download_and_unzip_protectedplanet(
                         pathlib.Path(inner_zipname).unlink(missing_ok=True)
 
                         logger.info(f"{resource} - Successfully unzipped file '{fzip}'")
-                    except:
+                    except Exception as e:
                         logger.warning(
-                            f"Exception while unzipping file '{fzip}' for {resource_iter}: skipped file"
+                            f"Exception while unzipping file '{fzip}' for {resource_iter} with exception message '{e}': skipped file"
                         )
 
                 # close and remove outer zip file
@@ -351,9 +353,9 @@ def download_and_unzip_protectedplanet(
 
                 downloaded = True
                 break
-            except:
+            except Exception as e:
                 logger.warning(
-                    f"Failed download resource '{resource_iter}' from cloud '{url_iter}'."
+                    f"Failed download resource '{resource_iter}' from cloud '{url_iter}' with exception message '{e}'."
                 )
                 current_first_day = get_first_day_of_previous_month(current_first_day)
 
@@ -411,8 +413,10 @@ def download_and_unpack(
                 pathlib.Path(file_path).unlink(missing_ok=True)
             logger.info(f"Downloaded resource '{resource}' from cloud '{url}'.")
             return True
-        except:
-            logger.warning(f"Failed download resource '{resource}' from cloud '{url}'.")
+        except Exception as e:
+            logger.warning(
+                f"Failed download resource '{resource}' from cloud '{url}' with exception message '{e}'."
+            )
             return False
 
 
@@ -868,8 +872,10 @@ if __name__ == "__main__":
                     config_bundles[b_name], root_path, disable_progress=disable_progress
                 ):
                     downloaded_bundle = True
-            except Exception:
-                logger.warning(f"Error in downloading bundle {b_name} - host {host}")
+            except Exception as e:
+                logger.warning(
+                    f"Error in downloading bundle {b_name} - host {host} - with exception message '{e}'"
+                )
 
             if downloaded_bundle:
                 downloaded_bundles.append(b_name)

--- a/test/test_helpers.py
+++ b/test/test_helpers.py
@@ -27,6 +27,8 @@ from _helpers import (
     build_directory,
     change_to_script_dir,
     country_name_2_two_digits,
+    download_gadm,
+    download_gadm_build_shapes,
     get_conv_factors,
     get_current_directory_path,
     get_gadm_filename,
@@ -276,10 +278,30 @@ def test_get_path():
         "sub_path_5",
         "file.nc",
     )
+    file_name_path_one_list_unpacked = get_path(
+        path_cwd,
+        *[
+            "sub_path_1",
+            "sub_path_2",
+            "sub_path_3",
+            "sub_path_4",
+            "sub_path_5",
+            "file.nc",
+        ],
+    )
     path_name_path_two = get_path(
         pathlib.Path(__file__).parent, "..", "logs", "rule.log"
     )
     assert str(file_name_path_one) == os.path.join(
+        path_cwd,
+        "sub_path_1",
+        "sub_path_2",
+        "sub_path_3",
+        "sub_path_4",
+        "sub_path_5",
+        "file.nc",
+    )
+    assert str(file_name_path_one_list_unpacked) == os.path.join(
         path_cwd,
         "sub_path_1",
         "sub_path_2",
@@ -560,4 +582,21 @@ def test_get_gadm_url():
     assert (
         url_no_zip_gadm41
         == f"https://geodata.ucdavis.edu/gadm/gadm4.1/gpkg/{gadm_filename}.gpkg"
+    )
+
+
+def test_download_gadm():
+    """
+    Verify what is returned by download_gadm.
+    """
+    file_prefix = "gadm41_"
+    gadm_url_prefix = "https://geodata.ucdavis.edu/gadm/gadm4.1/gpkg/"
+    gadm_input_file_args = ["data", "gadm"]
+    gadm_input_file_gpkg_old, gadm_filename_old = download_gadm_build_shapes("XK")
+    gadm_input_file_gpkg_new, gadm_filename_new = download_gadm(
+        "XK",
+        file_prefix,
+        gadm_url_prefix,
+        gadm_input_file_args,
+        use_zip_file=False,
     )

--- a/test/test_helpers.py
+++ b/test/test_helpers.py
@@ -28,7 +28,6 @@ from _helpers import (
     change_to_script_dir,
     country_name_2_two_digits,
     download_gadm,
-    download_gadm_build_shapes,
     download_GADM_helpers_pes,
     get_conv_factors,
     get_current_directory_path,
@@ -590,10 +589,10 @@ def test_download_gadm():
     """
     Verify what is returned by download_gadm.
     """
+    # test for geodata
     file_prefix_geodata = "gadm41_"
     gadm_url_prefix_geodata = "https://geodata.ucdavis.edu/gadm/gadm4.1/gpkg/"
     gadm_input_file_args_geodata = ["data", "gadm"]
-    # gadm_input_file_gpkg_old, gadm_filename_old = download_GADM_helpers_pes("XK")
     gadm_input_file_gpkg_geodata, gadm_filename_geodata = download_gadm(
         "XK",
         file_prefix_geodata,
@@ -605,3 +604,19 @@ def test_download_gadm():
         path_cwd, "data/gadm/gadm41_XKO/gadm41_XKO.gpkg"
     )
     assert gadm_filename_geodata == "gadm41_XKO"
+
+    ## test for biogeo
+    # file_prefix_biogeo = "gadm36_"
+    # gadm_url_prefix_biogeo = "https://biogeo.ucdavis.edu/data/gadm3.6/gpkg/"
+    # gadm_input_file_args_biogeo = ["data", "raw", "gadm"]
+    # gadm_input_file_gpkg_biogeo, gadm_filename_biogeo = download_gadm(
+    #    "XK",
+    #    file_prefix_biogeo,
+    #    gadm_url_prefix_biogeo,
+    #    gadm_input_file_args_biogeo,
+    #    use_zip_file=True,
+    # )
+    # assert gadm_input_file_gpkg_biogeo == get_path(
+    #    path_cwd, "data/raw/gadm/gadm41_XKO/gadm41_XKO.gpkg"
+    # )
+    # assert gadm_filename_biogeo == "gadm41_XKO"

--- a/test/test_helpers.py
+++ b/test/test_helpers.py
@@ -549,42 +549,13 @@ def test_get_gadm_url():
     """
     Verify what is returned by get_gadm_url.
     """
-    gadm_filename = get_gadm_filename("XK")
-    url_with_zip_gadm36 = get_gadm_url(
-        "https://biogeo.ucdavis.edu/data/gadm3.6/gpkg/",
-        gadm_filename,
-        use_zip_file=True,
-    )
-    url_no_zip_gadm36 = get_gadm_url(
-        "https://biogeo.ucdavis.edu/data/gadm3.6/gpkg/",
-        gadm_filename,
-        use_zip_file=False,
-    )
-    assert (
-        url_with_zip_gadm36
-        == f"https://biogeo.ucdavis.edu/data/gadm3.6/gpkg/{gadm_filename}_gpkg.zip"
-    )
-    assert (
-        url_no_zip_gadm36
-        == f"https://biogeo.ucdavis.edu/data/gadm3.6/gpkg/{gadm_filename}.gpkg"
-    )
-
-    url_with_zip_gadm41 = get_gadm_url(
+    gadm_filename = get_gadm_filename(get_gadm_country_code("XK"))
+    url_gadm41 = get_gadm_url(
         "https://geodata.ucdavis.edu/gadm/gadm4.1/gpkg/",
         gadm_filename,
-        use_zip_file=True,
-    )
-    url_no_zip_gadm41 = get_gadm_url(
-        "https://geodata.ucdavis.edu/gadm/gadm4.1/gpkg/",
-        gadm_filename,
-        use_zip_file=False,
     )
     assert (
-        url_with_zip_gadm41
-        == f"https://geodata.ucdavis.edu/gadm/gadm4.1/gpkg/{gadm_filename}_gpkg.zip"
-    )
-    assert (
-        url_no_zip_gadm41
+        url_gadm41
         == f"https://geodata.ucdavis.edu/gadm/gadm4.1/gpkg/{gadm_filename}.gpkg"
     )
 
@@ -593,28 +564,6 @@ def test_download_gadm():
     """
     Verify what is returned by download_gadm.
     """
-    # test data version 3.6
-    file_prefix_36 = "gadm36_"
-    gadm_url_prefix_36 = "https://geodata.ucdavis.edu/gadm/gadm3.6/gpkg/"
-    gadm_input_file_args_36 = ["data", "raw", "gadm"]
-    gadm_input_file_gpkg_36, gadm_filename_36 = download_gadm(
-        "XK",
-        file_prefix_36,
-        gadm_url_prefix_36,
-        gadm_input_file_args_36,
-        update=True,
-        use_zip_file=True,
-    )
-    assert gadm_input_file_gpkg_36 == get_path(
-        path_cwd, "data/raw/gadm/gadm36_XKO/gadm36_XKO.gpkg"
-    )
-    assert gadm_filename_36 == "gadm36_XKO"
-    list_layers_36 = fiona.listlayers(gadm_input_file_gpkg_36)
-    assert list_layers_36[0] == "gadm36_XKO_2"
-    assert list_layers_36[1] == "gadm36_XKO_1"
-    assert list_layers_36[2] == "gadm36_XKO_0"
-
-    # test data version 4.1
     file_prefix_41 = "gadm41_"
     gadm_url_prefix_41 = "https://geodata.ucdavis.edu/gadm/gadm4.1/gpkg/"
     gadm_input_file_args_41 = ["data", "gadm"]
@@ -624,7 +573,6 @@ def test_download_gadm():
         gadm_url_prefix_41,
         gadm_input_file_args_41,
         update=True,
-        use_zip_file=False,
     )
     assert gadm_input_file_gpkg_41 == get_path(
         path_cwd, "data/gadm/gadm41_XKO/gadm41_XKO.gpkg"

--- a/test/test_helpers.py
+++ b/test/test_helpers.py
@@ -30,6 +30,7 @@ from _helpers import (
     get_conv_factors,
     get_current_directory_path,
     get_gadm_filename,
+    get_gadm_url,
     get_path,
     get_path_size,
     get_relative_path,
@@ -471,6 +472,9 @@ def test_aggregate_fuels():
 
 
 def test_get_gadm_filename():
+    """
+    Verify what is returned by get_gadm_filename.
+    """
     # Kosovo
     assert get_gadm_filename("XK") == "gadm41_XKO"
     # Clipperton island
@@ -511,3 +515,49 @@ def test_get_gadm_filename():
     assert get_gadm_filename("DE") == "gadm41_DEU"
     # Micronesia (Federated States of)
     assert get_gadm_filename("FM") == "gadm41_FSM"
+    # Micronesia (Federated States of) with different file_prefix
+    assert get_gadm_filename("FM", file_prefix="gadm456_") == "gadm456_FSM"
+
+
+def test_get_gadm_url():
+    """
+    Verify what is returned by get_gadm_url.
+    """
+    gadm_filename = get_gadm_filename("XK")
+    url_with_zip_gadm36 = get_gadm_url(
+        "https://biogeo.ucdavis.edu/data/gadm3.6/gpkg/",
+        gadm_filename,
+        use_zip_file=True,
+    )
+    url_no_zip_gadm36 = get_gadm_url(
+        "https://biogeo.ucdavis.edu/data/gadm3.6/gpkg/",
+        gadm_filename,
+        use_zip_file=False,
+    )
+    assert (
+        url_with_zip_gadm36
+        == f"https://biogeo.ucdavis.edu/data/gadm3.6/gpkg/{gadm_filename}_gpkg.zip"
+    )
+    assert (
+        url_no_zip_gadm36
+        == f"https://biogeo.ucdavis.edu/data/gadm3.6/gpkg/{gadm_filename}.gpkg"
+    )
+
+    url_with_zip_gadm41 = get_gadm_url(
+        "https://geodata.ucdavis.edu/gadm/gadm4.1/gpkg/",
+        gadm_filename,
+        use_zip_file=True,
+    )
+    url_no_zip_gadm41 = get_gadm_url(
+        "https://geodata.ucdavis.edu/gadm/gadm4.1/gpkg/",
+        gadm_filename,
+        use_zip_file=False,
+    )
+    assert (
+        url_with_zip_gadm41
+        == f"https://geodata.ucdavis.edu/gadm/gadm4.1/gpkg/{gadm_filename}_gpkg.zip"
+    )
+    assert (
+        url_no_zip_gadm41
+        == f"https://geodata.ucdavis.edu/gadm/gadm4.1/gpkg/{gadm_filename}.gpkg"
+    )

--- a/test/test_helpers.py
+++ b/test/test_helpers.py
@@ -545,7 +545,7 @@ def test_get_gadm_url():
     """
     Verify what is returned by get_gadm_url.
     """
-    gadm_filename = get_gadm_filename("XK")
+    gadm_filename = get_gadm_filename("FM")
     url_gadm41 = get_gadm_url(
         "https://geodata.ucdavis.edu/gadm/gadm4.1/gpkg/",
         gadm_filename,

--- a/test/test_helpers.py
+++ b/test/test_helpers.py
@@ -28,7 +28,6 @@ from _helpers import (
     change_to_script_dir,
     country_name_2_two_digits,
     download_gadm,
-    download_GADM_helpers_pes,
     get_conv_factors,
     get_current_directory_path,
     get_gadm_filename,
@@ -589,7 +588,7 @@ def test_download_gadm():
     """
     Verify what is returned by download_gadm.
     """
-    # test for geodata
+    # test data version 4.1
     file_prefix_geodata = "gadm41_"
     gadm_url_prefix_geodata = "https://geodata.ucdavis.edu/gadm/gadm4.1/gpkg/"
     gadm_input_file_args_geodata = ["data", "gadm"]
@@ -598,6 +597,7 @@ def test_download_gadm():
         file_prefix_geodata,
         gadm_url_prefix_geodata,
         gadm_input_file_args_geodata,
+        update=True,
         use_zip_file=False,
     )
     assert gadm_input_file_gpkg_geodata == get_path(
@@ -605,18 +605,19 @@ def test_download_gadm():
     )
     assert gadm_filename_geodata == "gadm41_XKO"
 
-    ## test for biogeo
-    # file_prefix_biogeo = "gadm36_"
-    # gadm_url_prefix_biogeo = "https://biogeo.ucdavis.edu/data/gadm3.6/gpkg/"
-    # gadm_input_file_args_biogeo = ["data", "raw", "gadm"]
-    # gadm_input_file_gpkg_biogeo, gadm_filename_biogeo = download_gadm(
-    #    "XK",
-    #    file_prefix_biogeo,
-    #    gadm_url_prefix_biogeo,
-    #    gadm_input_file_args_biogeo,
-    #    use_zip_file=True,
-    # )
-    # assert gadm_input_file_gpkg_biogeo == get_path(
-    #    path_cwd, "data/raw/gadm/gadm41_XKO/gadm41_XKO.gpkg"
-    # )
-    # assert gadm_filename_biogeo == "gadm41_XKO"
+    # test data version 3.6
+    file_prefix_biogeo = "gadm36_"
+    gadm_url_prefix_biogeo = "https://geodata.ucdavis.edu/gadm/gadm3.6/gpkg/"
+    gadm_input_file_args_biogeo = ["data", "raw", "gadm"]
+    gadm_input_file_gpkg_biogeo, gadm_filename_biogeo = download_gadm(
+        "XK",
+        file_prefix_biogeo,
+        gadm_url_prefix_biogeo,
+        gadm_input_file_args_biogeo,
+        update=True,
+        use_zip_file=True,
+    )
+    assert gadm_input_file_gpkg_biogeo == get_path(
+        path_cwd, "data/raw/gadm/gadm36_XKO/gadm36_XKO.gpkg"
+    )
+    assert gadm_filename_biogeo == "gadm36_XKO"

--- a/test/test_helpers.py
+++ b/test/test_helpers.py
@@ -31,7 +31,6 @@ from _helpers import (
     download_gadm,
     get_conv_factors,
     get_current_directory_path,
-    get_gadm_country_code,
     get_gadm_filename,
     get_gadm_url,
     get_path,
@@ -499,57 +498,54 @@ def test_get_gadm_filename():
     Verify what is returned by get_gadm_filename.
     """
     # Kosovo
-    assert get_gadm_filename(get_gadm_country_code("XK")) == "gadm41_XKO"
+    assert get_gadm_filename("XK") == "gadm41_XKO"
     # Clipperton island
-    assert get_gadm_filename(get_gadm_country_code("CP")) == "gadm41_XCL"
+    assert get_gadm_filename("CP") == "gadm41_XCL"
     # Saint-Martin
-    assert get_gadm_filename(get_gadm_country_code("SX")) == "gadm41_MAF"
+    assert get_gadm_filename("SX") == "gadm41_MAF"
     # French Southern Territories
-    assert get_gadm_filename(get_gadm_country_code("TF")) == "gadm41_ATF"
+    assert get_gadm_filename("TF") == "gadm41_ATF"
     # Aland
-    assert get_gadm_filename(get_gadm_country_code("AX")) == "gadm41_ALA"
+    assert get_gadm_filename("AX") == "gadm41_ALA"
     # British Indian Ocean Territory
-    assert get_gadm_filename(get_gadm_country_code("IO")) == "gadm41_IOT"
+    assert get_gadm_filename("IO") == "gadm41_IOT"
     # Cocos Islands
-    assert get_gadm_filename(get_gadm_country_code("CC")) == "gadm41_CCK"
+    assert get_gadm_filename("CC") == "gadm41_CCK"
     # Norfolk
-    assert get_gadm_filename(get_gadm_country_code("NF")) == "gadm41_NFK"
+    assert get_gadm_filename("NF") == "gadm41_NFK"
     # Pitcairn Islands
-    assert get_gadm_filename(get_gadm_country_code("PN")) == "gadm41_PCN"
+    assert get_gadm_filename("PN") == "gadm41_PCN"
     # Jersey
-    assert get_gadm_filename(get_gadm_country_code("JE")) == "gadm41_JEY"
+    assert get_gadm_filename("JE") == "gadm41_JEY"
     # Spratly Islands
-    assert get_gadm_filename(get_gadm_country_code("XS")) == "gadm41_XSP"
+    assert get_gadm_filename("XS") == "gadm41_XSP"
     # Guernsey
-    assert get_gadm_filename(get_gadm_country_code("GG")) == "gadm41_GGY"
+    assert get_gadm_filename("GG") == "gadm41_GGY"
     # United States Minor Outlying Islands
-    assert get_gadm_filename(get_gadm_country_code("UM")) == "gadm41_UMI"
+    assert get_gadm_filename("UM") == "gadm41_UMI"
     # Svalbard islands
-    assert get_gadm_filename(get_gadm_country_code("SJ")) == "gadm41_SJM"
+    assert get_gadm_filename("SJ") == "gadm41_SJM"
     # Christmas island
-    assert get_gadm_filename(get_gadm_country_code("CX")) == "gadm41_CXR"
+    assert get_gadm_filename("CX") == "gadm41_CXR"
     # Afghanistan
-    assert get_gadm_filename(get_gadm_country_code("AF")) == "gadm41_AFG"
+    assert get_gadm_filename("AF") == "gadm41_AFG"
     # American Samoa
-    assert get_gadm_filename(get_gadm_country_code("AS")) == "gadm41_ASM"
+    assert get_gadm_filename("AS") == "gadm41_ASM"
     # Aruba
-    assert get_gadm_filename(get_gadm_country_code("AW")) == "gadm41_ABW"
+    assert get_gadm_filename("AW") == "gadm41_ABW"
     # Germany
-    assert get_gadm_filename(get_gadm_country_code("DE")) == "gadm41_DEU"
+    assert get_gadm_filename("DE") == "gadm41_DEU"
     # Micronesia (Federated States of)
-    assert get_gadm_filename(get_gadm_country_code("FM")) == "gadm41_FSM"
+    assert get_gadm_filename("FM") == "gadm41_FSM"
     # Micronesia (Federated States of) with different file_prefix
-    assert (
-        get_gadm_filename(get_gadm_country_code("FM"), file_prefix="gadm456_")
-        == "gadm456_FSM"
-    )
+    assert get_gadm_filename("FM", file_prefix="gadm456_") == "gadm456_FSM"
 
 
 def test_get_gadm_url():
     """
     Verify what is returned by get_gadm_url.
     """
-    gadm_filename = get_gadm_filename(get_gadm_country_code("XK"))
+    gadm_filename = get_gadm_filename("XK")
     url_gadm41 = get_gadm_url(
         "https://geodata.ucdavis.edu/gadm/gadm4.1/gpkg/",
         gadm_filename,

--- a/test/test_helpers.py
+++ b/test/test_helpers.py
@@ -17,6 +17,7 @@ from test.conftest import (
     get_temp_file,
 )
 
+import fiona
 import numpy as np
 import pandas as pd
 
@@ -588,36 +589,44 @@ def test_download_gadm():
     """
     Verify what is returned by download_gadm.
     """
-    # test data version 4.1
-    file_prefix_geodata = "gadm41_"
-    gadm_url_prefix_geodata = "https://geodata.ucdavis.edu/gadm/gadm4.1/gpkg/"
-    gadm_input_file_args_geodata = ["data", "gadm"]
-    gadm_input_file_gpkg_geodata, gadm_filename_geodata = download_gadm(
-        "XK",
-        file_prefix_geodata,
-        gadm_url_prefix_geodata,
-        gadm_input_file_args_geodata,
-        update=True,
-        use_zip_file=False,
-    )
-    assert gadm_input_file_gpkg_geodata == get_path(
-        path_cwd, "data/gadm/gadm41_XKO/gadm41_XKO.gpkg"
-    )
-    assert gadm_filename_geodata == "gadm41_XKO"
-
     # test data version 3.6
-    file_prefix_biogeo = "gadm36_"
-    gadm_url_prefix_biogeo = "https://geodata.ucdavis.edu/gadm/gadm3.6/gpkg/"
-    gadm_input_file_args_biogeo = ["data", "raw", "gadm"]
-    gadm_input_file_gpkg_biogeo, gadm_filename_biogeo = download_gadm(
+    file_prefix_36 = "gadm36_"
+    gadm_url_prefix_36 = "https://geodata.ucdavis.edu/gadm/gadm3.6/gpkg/"
+    gadm_input_file_args_36 = ["data", "raw", "gadm"]
+    gadm_input_file_gpkg_36, gadm_filename_36 = download_gadm(
         "XK",
-        file_prefix_biogeo,
-        gadm_url_prefix_biogeo,
-        gadm_input_file_args_biogeo,
+        file_prefix_36,
+        gadm_url_prefix_36,
+        gadm_input_file_args_36,
         update=True,
         use_zip_file=True,
     )
-    assert gadm_input_file_gpkg_biogeo == get_path(
+    assert gadm_input_file_gpkg_36 == get_path(
         path_cwd, "data/raw/gadm/gadm36_XKO/gadm36_XKO.gpkg"
     )
-    assert gadm_filename_biogeo == "gadm36_XKO"
+    assert gadm_filename_36 == "gadm36_XKO"
+    list_layers_36 = fiona.listlayers(gadm_input_file_gpkg_36)
+    assert list_layers_36[0] == "gadm36_XKO_2"
+    assert list_layers_36[1] == "gadm36_XKO_1"
+    assert list_layers_36[2] == "gadm36_XKO_0"
+
+    # test data version 4.1
+    file_prefix_41 = "gadm41_"
+    gadm_url_prefix_41 = "https://geodata.ucdavis.edu/gadm/gadm4.1/gpkg/"
+    gadm_input_file_args_41 = ["data", "gadm"]
+    gadm_input_file_gpkg_41, gadm_filename_41 = download_gadm(
+        "XK",
+        file_prefix_41,
+        gadm_url_prefix_41,
+        gadm_input_file_args_41,
+        update=True,
+        use_zip_file=False,
+    )
+    assert gadm_input_file_gpkg_41 == get_path(
+        path_cwd, "data/gadm/gadm41_XKO/gadm41_XKO.gpkg"
+    )
+    assert gadm_filename_41 == "gadm41_XKO"
+    list_layers_41 = fiona.listlayers(gadm_input_file_gpkg_41)
+    assert list_layers_41[0] == "ADM_ADM_0"
+    assert list_layers_41[1] == "ADM_ADM_1"
+    assert list_layers_41[2] == "ADM_ADM_2"

--- a/test/test_helpers.py
+++ b/test/test_helpers.py
@@ -29,6 +29,7 @@ from _helpers import (
     country_name_2_two_digits,
     download_gadm,
     download_gadm_build_shapes,
+    download_GADM_helpers_pes,
     get_conv_factors,
     get_current_directory_path,
     get_gadm_filename,
@@ -589,14 +590,18 @@ def test_download_gadm():
     """
     Verify what is returned by download_gadm.
     """
-    file_prefix = "gadm41_"
-    gadm_url_prefix = "https://geodata.ucdavis.edu/gadm/gadm4.1/gpkg/"
-    gadm_input_file_args = ["data", "gadm"]
-    gadm_input_file_gpkg_old, gadm_filename_old = download_gadm_build_shapes("XK")
-    gadm_input_file_gpkg_new, gadm_filename_new = download_gadm(
+    file_prefix_geodata = "gadm41_"
+    gadm_url_prefix_geodata = "https://geodata.ucdavis.edu/gadm/gadm4.1/gpkg/"
+    gadm_input_file_args_geodata = ["data", "gadm"]
+    # gadm_input_file_gpkg_old, gadm_filename_old = download_GADM_helpers_pes("XK")
+    gadm_input_file_gpkg_geodata, gadm_filename_geodata = download_gadm(
         "XK",
-        file_prefix,
-        gadm_url_prefix,
-        gadm_input_file_args,
+        file_prefix_geodata,
+        gadm_url_prefix_geodata,
+        gadm_input_file_args_geodata,
         use_zip_file=False,
     )
+    assert gadm_input_file_gpkg_geodata == get_path(
+        path_cwd, "data/gadm/gadm41_XKO/gadm41_XKO.gpkg"
+    )
+    assert gadm_filename_geodata == "gadm41_XKO"

--- a/test/test_helpers.py
+++ b/test/test_helpers.py
@@ -29,6 +29,7 @@ from _helpers import (
     country_name_2_two_digits,
     get_conv_factors,
     get_current_directory_path,
+    get_gadm_filename,
     get_path,
     get_path_size,
     get_relative_path,
@@ -467,3 +468,46 @@ def test_aggregate_fuels():
     Verify what is returned by aggregate_fuels.
     """
     assert np.isnan(aggregate_fuels("non-industry"))
+
+
+def test_get_gadm_filename():
+    # Kosovo
+    assert get_gadm_filename("XK") == "gadm41_XKO"
+    # Clipperton island
+    assert get_gadm_filename("CP") == "gadm41_XCL"
+    # Saint-Martin
+    assert get_gadm_filename("SX") == "gadm41_MAF"
+    # French Southern Territories
+    assert get_gadm_filename("TF") == "gadm41_ATF"
+    # Aland
+    assert get_gadm_filename("AX") == "gadm41_ALA"
+    # British Indian Ocean Territory
+    assert get_gadm_filename("IO") == "gadm41_IOT"
+    # Cocos Islands
+    assert get_gadm_filename("CC") == "gadm41_CCK"
+    # Norfolk
+    assert get_gadm_filename("NF") == "gadm41_NFK"
+    # Pitcairn Islands
+    assert get_gadm_filename("PN") == "gadm41_PCN"
+    # Jersey
+    assert get_gadm_filename("JE") == "gadm41_JEY"
+    # Spratly Islands
+    assert get_gadm_filename("XS") == "gadm41_XSP"
+    # Guernsey
+    assert get_gadm_filename("GG") == "gadm41_GGY"
+    # United States Minor Outlying Islands
+    assert get_gadm_filename("UM") == "gadm41_UMI"
+    # Svalbard islands
+    assert get_gadm_filename("SJ") == "gadm41_SJM"
+    # Christmas island
+    assert get_gadm_filename("CX") == "gadm41_CXR"
+    # Afghanistan
+    assert get_gadm_filename("AF") == "gadm41_AFG"
+    # American Samoa
+    assert get_gadm_filename("AS") == "gadm41_ASM"
+    # Aruba
+    assert get_gadm_filename("AW") == "gadm41_ABW"
+    # Germany
+    assert get_gadm_filename("DE") == "gadm41_DEU"
+    # Micronesia (Federated States of)
+    assert get_gadm_filename("FM") == "gadm41_FSM"

--- a/test/test_helpers.py
+++ b/test/test_helpers.py
@@ -31,6 +31,7 @@ from _helpers import (
     download_gadm,
     get_conv_factors,
     get_current_directory_path,
+    get_gadm_country_code,
     get_gadm_filename,
     get_gadm_url,
     get_path,
@@ -498,47 +499,50 @@ def test_get_gadm_filename():
     Verify what is returned by get_gadm_filename.
     """
     # Kosovo
-    assert get_gadm_filename("XK") == "gadm41_XKO"
+    assert get_gadm_filename(get_gadm_country_code("XK")) == "gadm41_XKO"
     # Clipperton island
-    assert get_gadm_filename("CP") == "gadm41_XCL"
+    assert get_gadm_filename(get_gadm_country_code("CP")) == "gadm41_XCL"
     # Saint-Martin
-    assert get_gadm_filename("SX") == "gadm41_MAF"
+    assert get_gadm_filename(get_gadm_country_code("SX")) == "gadm41_MAF"
     # French Southern Territories
-    assert get_gadm_filename("TF") == "gadm41_ATF"
+    assert get_gadm_filename(get_gadm_country_code("TF")) == "gadm41_ATF"
     # Aland
-    assert get_gadm_filename("AX") == "gadm41_ALA"
+    assert get_gadm_filename(get_gadm_country_code("AX")) == "gadm41_ALA"
     # British Indian Ocean Territory
-    assert get_gadm_filename("IO") == "gadm41_IOT"
+    assert get_gadm_filename(get_gadm_country_code("IO")) == "gadm41_IOT"
     # Cocos Islands
-    assert get_gadm_filename("CC") == "gadm41_CCK"
+    assert get_gadm_filename(get_gadm_country_code("CC")) == "gadm41_CCK"
     # Norfolk
-    assert get_gadm_filename("NF") == "gadm41_NFK"
+    assert get_gadm_filename(get_gadm_country_code("NF")) == "gadm41_NFK"
     # Pitcairn Islands
-    assert get_gadm_filename("PN") == "gadm41_PCN"
+    assert get_gadm_filename(get_gadm_country_code("PN")) == "gadm41_PCN"
     # Jersey
-    assert get_gadm_filename("JE") == "gadm41_JEY"
+    assert get_gadm_filename(get_gadm_country_code("JE")) == "gadm41_JEY"
     # Spratly Islands
-    assert get_gadm_filename("XS") == "gadm41_XSP"
+    assert get_gadm_filename(get_gadm_country_code("XS")) == "gadm41_XSP"
     # Guernsey
-    assert get_gadm_filename("GG") == "gadm41_GGY"
+    assert get_gadm_filename(get_gadm_country_code("GG")) == "gadm41_GGY"
     # United States Minor Outlying Islands
-    assert get_gadm_filename("UM") == "gadm41_UMI"
+    assert get_gadm_filename(get_gadm_country_code("UM")) == "gadm41_UMI"
     # Svalbard islands
-    assert get_gadm_filename("SJ") == "gadm41_SJM"
+    assert get_gadm_filename(get_gadm_country_code("SJ")) == "gadm41_SJM"
     # Christmas island
-    assert get_gadm_filename("CX") == "gadm41_CXR"
+    assert get_gadm_filename(get_gadm_country_code("CX")) == "gadm41_CXR"
     # Afghanistan
-    assert get_gadm_filename("AF") == "gadm41_AFG"
+    assert get_gadm_filename(get_gadm_country_code("AF")) == "gadm41_AFG"
     # American Samoa
-    assert get_gadm_filename("AS") == "gadm41_ASM"
+    assert get_gadm_filename(get_gadm_country_code("AS")) == "gadm41_ASM"
     # Aruba
-    assert get_gadm_filename("AW") == "gadm41_ABW"
+    assert get_gadm_filename(get_gadm_country_code("AW")) == "gadm41_ABW"
     # Germany
-    assert get_gadm_filename("DE") == "gadm41_DEU"
+    assert get_gadm_filename(get_gadm_country_code("DE")) == "gadm41_DEU"
     # Micronesia (Federated States of)
-    assert get_gadm_filename("FM") == "gadm41_FSM"
+    assert get_gadm_filename(get_gadm_country_code("FM")) == "gadm41_FSM"
     # Micronesia (Federated States of) with different file_prefix
-    assert get_gadm_filename("FM", file_prefix="gadm456_") == "gadm456_FSM"
+    assert (
+        get_gadm_filename(get_gadm_country_code("FM"), file_prefix="gadm456_")
+        == "gadm456_FSM"
+    )
 
 
 def test_get_gadm_url():


### PR DESCRIPTION
# Changes proposed in this Pull Request

## Changes on GADM

This pull requests follows up on the comments made by @pz-max on pull request https://github.com/open-energy-transition/pypsa-earth/pull/2

 I noticed that the methos get_GADM_layer and download_GADM are duplicated in 
-  pypsa-earth/scripts/build_shapes.py
-  pypsa-earth-sec/scripts/build_shapes.py
-  pypsa-earth-sec/scripts/helpers.py
-  pypsa-earth-sec/scripts/prepare_gas_network.py

The codes are slightly different and I could pinpoint the cause. It seems in fact that **pypsa-earth** uses the GADM 4.1 version data, whereas **pypsa-earth-sec** uses GADM 4.1 version data in _build_shapes.py_ but the GADM 3.6 version data in the helpers. In detail:

**Methods using GADM 4.1 version data**
-  pypsa-earth/scripts/build_shapes.py
-  pypsa-earth-sec/scripts/build_shapes.py
-  pypsa-earth-sec/scripts/prepare_gas_network.py

**Methods using GADM 3.6 version data**
- pypsa-earth-sec/scripts/helpers.py

I managed to create a unified version of the _download_gadm_ and _get_gadm_layer_ and to unit test what feasible.

### Tests performed

On top of the above-mentioned unit tests, I have also executed the CI/CD locally with the code from the _main_ and this branch. In particular, the build_shapes.py script is used in **rule build_shapes**, which produces as output:

1. "shapes/country_shapes.geojson"
2. "shapes/offshore_shapes.geojson"
3. "shapes/africa_shape.geojson"
4. "shapes/gadm_shapes.geojson

The files obtained from the main branch are available at [resources_main_branch.zip](https://github.com/user-attachments/files/16070052/resources_main_branch.zip) and the files obtained from this branch are available at [resources_new_branch.zip](https://github.com/user-attachments/files/16070060/resources_new_branch.zip).

To compare them, I created the notebook [shapes_comparison.ipynb.zip](https://github.com/user-attachments/files/16070191/shapes_comparison.ipynb.zip).

## Additional changes

### Upgrade of the Node 16 actions

We used to get the following warning 
`Node.js 16 actions are deprecated. Please update the following actions to use Node.js 20: actions/checkout@v3, actions/cache@v3. For more information see: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/.`

I solved it by upgrading @v2 to @v3 in the workflows files ci-linux.yaml, ci-windows.yaml and ci-mac.yaml

### Creation of a Mac dedicated environment.yaml 

In the environment.yaml file we are setting `ipopt[version='<3.13.3']`. This condition works well for Windows and Linux, however in the ci-mac.yaml yields (see this [example](https://github.com/open-energy-transition/pypsa-earth/actions/runs/9793680326/job/27042106068))

` PackagesNotFoundError: The following packages are not available from current channels:

  - ipopt[version='<3.13.3']`

The easiest solution would be to remove the restriction on the ipopt version. If we do so however, ci-linux.yaml and ci-mac.yaml work fine, but the ci-windows.yaml fails (see this [example](https://github.com/open-energy-transition/pypsa-earth/actions/runs/9791397486/job/27036968619))

`WARNING:__main__:The configured solver `glpk` does not support quadratic objectives. Falling back to `ipopt`.
WARNING:pyomo.solvers:Could not locate the 'ipopt' executable, which is required for solver ipopt
ERROR:_helpers:An error happened in module 'C:\\Users\\runneradmin\\miniconda3\\envs\\pypsa-earth\\lib\\site-packages\\pyomo\\opt\\solver\\shellcmd.py', function 'available': No executable found for solver 'ipopt'`

I have therefore introduced a mac-dedicated environment.mac.yaml file where I remove the ipopt version restriction and modified the ci-mac.yaml workflow file to use it. 

## Checklist

- [x] I consent to the release of this PR's code under the AGPLv3 license and non-code contributions under CC0-1.0 and CC-BY-4.0.
- [x] I tested my contribution locally and it seems to work fine.
- [ ] Code and workflow changes are sufficiently documented.
- [ ] Newly introduced dependencies are added to `envs/environment.yaml` and `doc/requirements.txt`.
- [ ] Changes in configuration options are added in all of `config.default.yaml` and `config.tutorial.yaml`.
- [ ] Add a test config or line additions to `test/` (note tests are changing the config.tutorial.yaml)
- [ ] Changes in configuration options are also documented in `doc/configtables/*.csv` and line references are adjusted in `doc/configuration.rst` and `doc/tutorial.rst`.
- [ ] A note for the release notes `doc/release_notes.rst` is amended in the format of previous release notes, including reference to the requested PR.
