### PR TITLE
config: experimenting with the upgrade of the pypsa version 

### DIFF
--- a/Snakefile
+++ b/Snakefile
@@ -826,6 +826,11 @@ if config["monte_carlo"]["options"].get("add_to_snakefile", False) == False:
                 + RDIR
                 + "solve_network/elec_s{simpl}_{clusters}_ec_l{ll}_{opts}_solver.log"
             ),
+            memory=normpath(
+                "logs/"
+                + RDIR
+                + "solve_network/elec_s{simpl}_{clusters}_ec_l{ll}_{opts}_memory.log"
+            ),
             python="logs/"
             + RDIR
             + "solve_network/elec_s{simpl}_{clusters}_ec_l{ll}_{opts}_python.log",

--- a/Snakefile
+++ b/Snakefile
@@ -603,6 +603,7 @@ if config["augmented_line_connection"].get("add_to_snakefile", False) == True:
 
     rule cluster_network:
         params:
+            aggregation_strategies=config["cluster_options"]["aggregation_strategies"],
             build_shape_options=config["build_shape_options"],
             electricity=config["electricity"],
             costs=config["costs"],
@@ -688,6 +689,7 @@ if config["augmented_line_connection"].get("add_to_snakefile", False) == False:
 
     rule cluster_network:
         params:
+            aggregation_strategies=config["cluster_options"]["aggregation_strategies"],
             build_shape_options=config["build_shape_options"],
             electricity=config["electricity"],
             costs=config["costs"],

--- a/Snakefile
+++ b/Snakefile
@@ -560,6 +560,7 @@ rule add_electricity:
 
 rule simplify_network:
     params:
+        aggregation_strategies=config["cluster_options"]["aggregation_strategies"],
         renewable=config["renewable"],
         geo_crs=config["crs"]["geo_crs"],
         cluster_options=config["cluster_options"],

--- a/envs/environment.fixed.yaml
+++ b/envs/environment.fixed.yaml
@@ -187,7 +187,7 @@ dependencies:
 - importlib_resources=6.4.5
 - inflate64=1.0.0
 - iniconfig=2.0.0
-- ipopt=3.13.2
+- ipopt=3.14.16
 - ipykernel=6.29.5
 - ipython=8.27.0
 - isoduration=20.11.0

--- a/envs/environment.fixed.yaml
+++ b/envs/environment.fixed.yaml
@@ -440,6 +440,7 @@ dependencies:
 - pyshp=2.3.1
 - pysocks=1.7.1
 - pytables=3.10.1
+- pyscipopt=5.1.1
 - pytest=8.3.3
 - python=3.10.14
 - python-dateutil=2.9.0

--- a/envs/environment.fixed.yaml
+++ b/envs/environment.fixed.yaml
@@ -142,8 +142,8 @@ dependencies:
 - gdk-pixbuf=2.42.12
 - geographiclib=2.0
 - geojson-rewind=1.1.0
-- geopandas=0.14.3
-- geopandas-base=0.14.3
+- geopandas=1.0.1
+- geopandas-base=1.0.1
 - geopy=2.4.1
 - geos=3.12.2
 - geotiff=1.7.3
@@ -531,7 +531,7 @@ dependencies:
 - websocket-client=1.8.0
 - wheel=0.44.0
 - wrapt=1.16.0
-- xarray=2023.11.0
+- xarray=2024.9.0
 - xcb-util=0.4.1
 - xcb-util-image=0.4.0
 - xcb-util-keysyms=0.4.1

--- a/envs/environment.fixed.yaml
+++ b/envs/environment.fixed.yaml
@@ -434,7 +434,7 @@ dependencies:
 - pyparsing=3.1.4
 - pyppmd=1.1.0
 - pyproj=3.6.1
-- pypsa=0.24.0
+- pypsa=0.30.3
 - pyqt=5.15.9
 - pyqt5-sip=12.12.2
 - pyshp=2.3.1

--- a/envs/environment.yaml
+++ b/envs/environment.yaml
@@ -12,7 +12,7 @@ dependencies:
 - pip
 - mamba   # esp for windows build
 
-- pypsa>=0.30.3
+- pypsa>=0.30.3, < 0.31
 # - atlite>=0.2.4  # until https://github.com/PyPSA/atlite/issues/244 is not merged
 - dask
 - powerplantmatching

--- a/envs/environment.yaml
+++ b/envs/environment.yaml
@@ -30,9 +30,9 @@ dependencies:
 - lxml
 - numpy
 - pandas
-- geopandas>=0.11.0, <=0.14.3
-- fiona<1.10.0
-- xarray>=2023.11.0, <2023.12.0
+- geopandas>=1
+- fiona
+- xarray>=2023.11.0
 - netcdf4
 - networkx
 - scipy

--- a/envs/environment.yaml
+++ b/envs/environment.yaml
@@ -12,7 +12,7 @@ dependencies:
 - pip
 - mamba   # esp for windows build
 
-- pypsa>=0.24, <0.25
+- pypsa>=0.30.3
 # - atlite>=0.2.4  # until https://github.com/PyPSA/atlite/issues/244 is not merged
 - dask
 - powerplantmatching

--- a/envs/environment.yaml
+++ b/envs/environment.yaml
@@ -27,6 +27,7 @@ dependencies:
 - memory_profiler
 - ruamel.yaml<=0.17.26
 - pytables
+- pyscipopt
 - lxml
 - numpy
 - pandas

--- a/scripts/_helpers.py
+++ b/scripts/_helpers.py
@@ -25,7 +25,7 @@ import requests
 import snakemake as sm
 import yaml
 from fake_useragent import UserAgent
-from pypsa.clustering.spatial import _make_consense
+from pypsa.clustering.spatial import make_consense
 from pypsa.components import component_attrs, components
 from pypsa.descriptors import Dict
 from shapely.geometry import Point
@@ -506,7 +506,7 @@ def get_aggregation_strategies(aggregation_strategies):
     in the config.
     """
 
-    bus_strategies = dict(country=_make_consense("Bus", "country"))
+    bus_strategies = dict(country=make_consense("Bus", "country"))
     bus_strategies.update(aggregation_strategies.get("buses", {}))
 
     generator_strategies = {"build_year": lambda x: 0, "lifetime": lambda x: np.inf}

--- a/scripts/_helpers.py
+++ b/scripts/_helpers.py
@@ -498,23 +498,6 @@ def content_retrieve(url, data=None, headers=None, max_retries=3, backoff_factor
     raise Exception("Max retries exceeded")
 
 
-def get_aggregation_strategies(aggregation_strategies):
-    """
-    Default aggregation strategies that cannot be defined in .yaml format must
-    be specified within the function, otherwise (when defaults are passed in
-    the function's definition) they get lost when custom values are specified
-    in the config.
-    """
-
-    bus_strategies = dict(country=make_consense("Bus", "country"))
-    bus_strategies.update(aggregation_strategies.get("buses", {}))
-
-    generator_strategies = {"build_year": lambda x: 0, "lifetime": lambda x: np.inf}
-    generator_strategies.update(aggregation_strategies.get("generators", {}))
-
-    return bus_strategies, generator_strategies
-
-
 def mock_snakemake(rule_name, root_dir=None, submodule_dir=None, **wildcards):
     """
     This function is expected to be executed from the "scripts"-directory of "

--- a/scripts/_helpers.py
+++ b/scripts/_helpers.py
@@ -25,7 +25,6 @@ import requests
 import snakemake as sm
 import yaml
 from fake_useragent import UserAgent
-from pypsa.clustering.spatial import make_consense
 from pypsa.components import component_attrs, components
 from pypsa.descriptors import Dict
 from shapely.geometry import Point

--- a/scripts/_helpers.py
+++ b/scripts/_helpers.py
@@ -897,6 +897,16 @@ def get_last_commit_message(path):
     return last_commit_message
 
 
+def update_config_dictionary(
+    config_dict,
+    parameter_key_to_fill="lines",
+    dict_to_use={"geometry": "first", "bounds": "first"},
+):
+    config_dict.setdefault(parameter_key_to_fill, {})
+    config_dict[parameter_key_to_fill].update(dict_to_use)
+    return config_dict
+
+
 def get_path(*args):
     """
     It returns a new path string.

--- a/scripts/build_shapes.py
+++ b/scripts/build_shapes.py
@@ -123,8 +123,7 @@ def save_to_geojson(df, fn):
     # save file if the GeoDataFrame is non-empty
     if df.shape[0] > 0:
         df = df.reset_index()
-        schema = {**gpd.io.file.infer_schema(df), "geometry": "Unknown"}
-        df.to_file(fn, driver="GeoJSON", schema=schema)
+        df.to_file(fn, driver="GeoJSON")
     else:
         # create empty file to avoid issues with snakemake
         with open(fn, "w") as fp:

--- a/scripts/cluster_network.py
+++ b/scripts/cluster_network.py
@@ -121,13 +121,14 @@ Exemplary unsolved network clustered to 37 nodes:
     :align: center
 """
 
+import logging
 import pathlib
 from functools import reduce
 
 import geopandas as gpd
+import linopy
 import numpy as np
 import pandas as pd
-import pyomo.environ as po
 import pypsa
 from _helpers import (
     REGION_COLS,
@@ -334,47 +335,23 @@ def distribute_clusters(
         distribution_factor.sum(), 1.0, rtol=1e-3
     ), f"Country weights L must sum up to 1.0 when distributing clusters. Is {distribution_factor.sum()}."
 
-    m = po.ConcreteModel()
-
-    def n_bounds(model, *n_id):
-        """
-        Create a function that makes a bound pair for pyomo.
-
-        Use n_bounds(model, n_id) if N is Single-Index
-        Use n_bounds(model, *n_id) if N is Multi-Index
-        Example: https://pyomo.readthedocs.io/en/stable/pyomo_modeling_components/Variables.html
-
-        Returns
-        -------
-        bounds = A function (or Python object) that gives a (lower,upper) bound pair i.e.(1,10) for the variable
-        """
-        return (1, N[n_id])
-
-    m.n = po.Var(list(distribution_factor.index), bounds=n_bounds, domain=po.Integers)
-    m.tot = po.Constraint(expr=(po.summation(m.n) == n_clusters))
-    m.objective = po.Objective(
-        expr=sum(
-            (m.n[i] - distribution_factor.loc[i] * n_clusters) ** 2
-            for i in distribution_factor.index
-        ),
-        sense=po.minimize,
+    m = linopy.Model()
+    clusters = m.add_variables(
+        lower=1, upper=N, coords=[L.index], name="n", integer=True
     )
 
-    opt = po.SolverFactory(solver_name)
-    if not opt.has_capability("quadratic_objective"):
-        logger.warning(
-            f"The configured solver `{solver_name}` does not support quadratic objectives. Falling back to `ipopt`."
+    m.add_constraints(clusters.sum() == n_clusters, name="tot")
+    # leave out constant in objective (L * n_clusters) ** 2
+    m.objective = (clusters * clusters - 2 * clusters * L * n_clusters).sum()
+    if solver_name == "gurobi":
+        logging.getLogger("gurobipy").propagate = False
+    elif solver_name != "scip":
+        logger.info(
+            f"The configured solver `{solver_name}` does not support quadratic objectives. Falling back to `scip`."
         )
-        opt = po.SolverFactory("ipopt")
-
-    results = opt.solve(m)
-    assert (
-        results["Solver"][0]["Status"] == "ok"
-    ), f"Solver returned non-optimally: {results}"
-
-    return (
-        pd.Series(m.n.get_values(), index=distribution_factor.index).round().astype(int)
-    )
+        solver_name = "scip"
+    m.solve(solver_name=solver_name)
+    return m.solution["n"].to_series().astype(int)
 
 
 def busmap_for_gadm_clusters(inputs, n, gadm_level):

--- a/scripts/cluster_network.py
+++ b/scripts/cluster_network.py
@@ -133,9 +133,9 @@ from _helpers import (
     REGION_COLS,
     configure_logging,
     create_logger,
-    get_aggregation_strategies,
     mock_snakemake,
     normed,
+    update_config_dictionary,
     update_p_nom_max,
 )
 from add_electricity import load_costs
@@ -572,9 +572,11 @@ def clustering_for_n_clusters(
     extended_link_costs=0,
     focus_weights=None,
 ):
-    bus_strategies, generator_strategies = get_aggregation_strategies(
-        aggregation_strategies
-    )
+
+    line_strategies = aggregation_strategies.get("lines", dict())
+    bus_strategies = aggregation_strategies.get("buses", dict())
+    generator_strategies = aggregation_strategies.get("generators", dict())
+    one_port_strategies = aggregation_strategies.get("one_ports", dict())
 
     if not isinstance(custom_busmap, pd.Series):
         if alternative_clustering:
@@ -598,12 +600,14 @@ def clustering_for_n_clusters(
     clustering = get_clustering_from_busmap(
         n,
         busmap,
-        bus_strategies=bus_strategies,
         aggregate_generators_weighted=True,
         aggregate_generators_carriers=aggregate_carriers,
         aggregate_one_ports=["Load", "StorageUnit"],
         line_length_factor=line_length_factor,
+        line_strategies=line_strategies,
+        bus_strategies=bus_strategies,
         generator_strategies=generator_strategies,
+        one_port_strategies=one_port_strategies,
         scale_link_capital_costs=False,
     )
 
@@ -718,14 +722,27 @@ if __name__ == "__main__":
             ).all() or x.isnull().all(), "The `potential` configuration option must agree for all renewable carriers, for now!"
             return v
 
-        aggregation_strategies = snakemake.params.cluster_options.get(
-            "aggregation_strategies", {}
+        aggregation_strategies = snakemake.params.aggregation_strategies
+
+        # Aggregation strategies must be set for all columns
+        update_config_dictionary(
+            config_dict=aggregation_strategies,
+            parameter_key_to_fill="lines",
+            dict_to_use={"v_nom": "first", "geometry": "first", "bounds": "first"},
         )
-        # translate str entries of aggregation_strategies to pd.Series functions:
-        aggregation_strategies = {
-            p: {k: getattr(pd.Series, v) for k, v in aggregation_strategies[p].items()}
-            for p in aggregation_strategies.keys()
-        }
+        update_config_dictionary(
+            config_dict=aggregation_strategies,
+            parameter_key_to_fill="buses",
+            dict_to_use={
+                "v_nom": "first",
+                "lat": "mean",
+                "lon": "mean",
+                "tag_substation": "first",
+                "tag_area": "first",
+                "country": "first",
+            },
+        )
+
         custom_busmap = False  # snakemake.params.custom_busmap custom busmap is depreciated https://github.com/pypsa-meets-earth/pypsa-earth/pull/694
         if custom_busmap:
             busmap = pd.read_csv(

--- a/scripts/simplify_network.py
+++ b/scripts/simplify_network.py
@@ -95,8 +95,8 @@ import scipy as sp
 from _helpers import (
     configure_logging,
     create_logger,
-    get_aggregation_strategies,
     mock_snakemake,
+    update_config_dictionary,
     update_p_nom_max,
 )
 from add_electricity import load_costs
@@ -275,7 +275,7 @@ def _aggregate_and_move_components(
 
     _adjust_capital_costs_using_connection_costs(n, connection_costs_to_bus, output)
 
-    _, generator_strategies = get_aggregation_strategies(aggregation_strategies)
+    generator_strategies = aggregation_strategies["generators"]
 
     carriers = set(n.generators.carrier) - set(exclude_carriers)
     generators, generators_pnl = aggregateoneport(
@@ -591,19 +591,22 @@ def aggregate_to_substations(n, aggregation_strategies=dict(), buses_i=None):
     if not dist.empty:
         busmap.loc[buses_i] = dist.idxmin(1)
 
-    bus_strategies, generator_strategies = get_aggregation_strategies(
-        aggregation_strategies
-    )
+    line_strategies = aggregation_strategies.get("lines", dict())
+    bus_strategies = aggregation_strategies.get("buses", dict())
+    generator_strategies = aggregation_strategies.get("generators", dict())
+    one_port_strategies = aggregation_strategies.get("one_ports", dict())
 
     clustering = get_clustering_from_busmap(
         n,
         busmap,
-        bus_strategies=bus_strategies,
         aggregate_generators_weighted=True,
         aggregate_generators_carriers=None,
         aggregate_one_ports=["Load", "StorageUnit"],
         line_length_factor=1.0,
+        line_strategies=line_strategies,
+        bus_strategies=bus_strategies,
         generator_strategies=generator_strategies,
+        one_port_strategies=one_port_strategies,
         scale_link_capital_costs=False,
     )
     return clustering.network, busmap
@@ -851,19 +854,22 @@ def merge_into_network(n, threshold, aggregation_strategies=dict()):
     if (busmap.index == busmap).all():
         return n, n.buses.index.to_series()
 
-    bus_strategies, generator_strategies = get_aggregation_strategies(
-        aggregation_strategies
-    )
+    line_strategies = aggregation_strategies.get("lines", dict())
+    bus_strategies = aggregation_strategies.get("buses", dict())
+    generator_strategies = aggregation_strategies.get("generators", dict())
+    one_port_strategies = aggregation_strategies.get("one_ports", dict())
 
     clustering = get_clustering_from_busmap(
         n,
         busmap,
-        bus_strategies=bus_strategies,
         aggregate_generators_weighted=True,
         aggregate_generators_carriers=None,
         aggregate_one_ports=["Load", "StorageUnit"],
         line_length_factor=1.0,
+        line_strategies=line_strategies,
+        bus_strategies=bus_strategies,
         generator_strategies=generator_strategies,
+        one_port_strategies=one_port_strategies,
         scale_link_capital_costs=False,
     )
 
@@ -937,19 +943,22 @@ def merge_isolated_nodes(n, threshold, aggregation_strategies=dict()):
     if (busmap.index == busmap).all():
         return n, n.buses.index.to_series()
 
-    bus_strategies, generator_strategies = get_aggregation_strategies(
-        aggregation_strategies
-    )
+    line_strategies = aggregation_strategies.get("lines", dict())
+    bus_strategies = aggregation_strategies.get("buses", dict())
+    generator_strategies = aggregation_strategies.get("generators", dict())
+    one_port_strategies = aggregation_strategies.get("one_ports", dict())
 
     clustering = get_clustering_from_busmap(
         n,
         busmap,
-        bus_strategies=bus_strategies,
         aggregate_generators_weighted=True,
         aggregate_generators_carriers=None,
         aggregate_one_ports=["Load", "StorageUnit"],
         line_length_factor=1.0,
+        line_strategies=line_strategies,
+        bus_strategies=bus_strategies,
         generator_strategies=generator_strategies,
+        one_port_strategies=one_port_strategies,
         scale_link_capital_costs=False,
     )
 
@@ -977,14 +986,28 @@ if __name__ == "__main__":
         "exclude_carriers", []
     )
     hvdc_as_lines = snakemake.params.electricity["hvdc_as_lines"]
-    aggregation_strategies = snakemake.params.cluster_options.get(
-        "aggregation_strategies", {}
+
+    aggregation_strategies = snakemake.params.aggregation_strategies
+
+    # Aggregation strategies must be set for all columns
+    update_config_dictionary(
+        config_dict=aggregation_strategies,
+        parameter_key_to_fill="lines",
+        dict_to_use={"v_nom": "first", "geometry": "first", "bounds": "first"},
     )
-    # translate str entries of aggregation_strategies to pd.Series functions:
-    aggregation_strategies = {
-        p: {k: getattr(pd.Series, v) for k, v in aggregation_strategies[p].items()}
-        for p in aggregation_strategies.keys()
-    }
+    update_config_dictionary(
+        config_dict=aggregation_strategies,
+        parameter_key_to_fill="buses",
+        dict_to_use={
+            "v_nom": "first",
+            "lat": "mean",
+            "lon": "mean",
+            "tag_substation": "first",
+            "tag_area": "first",
+            "country": "first",
+        },
+    )
+
     n, trafo_map = simplify_network_to_base_voltage(n, linetype, base_voltage)
 
     Nyears = n.snapshot_weightings.objective.sum() / 8760
@@ -1089,7 +1112,7 @@ if __name__ == "__main__":
             solver_name,
             cluster_config.get("algorithm", "hac"),
             cluster_config.get("feature", None),
-            aggregation_strategies,
+            aggregation_strategies=aggregation_strategies,
         )
         busmaps.append(cluster_map)
 

--- a/scripts/simplify_network.py
+++ b/scripts/simplify_network.py
@@ -102,7 +102,6 @@ from _helpers import (
 from add_electricity import load_costs
 from cluster_network import cluster_regions, clustering_for_n_clusters
 from pypsa.clustering.spatial import (
-    aggregategenerators,
     aggregateoneport,
     busmap_by_stubs,
     get_clustering_from_busmap,
@@ -279,8 +278,12 @@ def _aggregate_and_move_components(
     _, generator_strategies = get_aggregation_strategies(aggregation_strategies)
 
     carriers = set(n.generators.carrier) - set(exclude_carriers)
-    generators, generators_pnl = aggregategenerators(
-        n, busmap, carriers=carriers, custom_strategies=generator_strategies
+    generators, generators_pnl = aggregateoneport(
+        n,
+        busmap,
+        "Generator",
+        carriers=carriers,
+        custom_strategies=generator_strategies,
     )
 
     replace_components(n, "Generator", generators, generators_pnl)

--- a/scripts/solve_network.py
+++ b/scripts/solve_network.py
@@ -972,7 +972,7 @@ def solve_network(n, config, solving={}, **kwargs):
         solving["solver_options"][set_of_options] if set_of_options else {}
     )
     kwargs["solver_name"] = solving["solver"]["name"]
-    kwargs["extra_functionality"] = extra_functionality
+    # kwargs["extra_functionality"] = extra_functionality
 
     logger.info("kwargs", kwargs)
     print("kwargs {}".format(kwargs))

--- a/scripts/solve_network.py
+++ b/scripts/solve_network.py
@@ -973,6 +973,9 @@ def solve_network(n, config, solving={}, **kwargs):
     )
     kwargs["solver_name"] = solving["solver"]["name"]
     kwargs["extra_functionality"] = extra_functionality
+
+    logger.info("kwargs", kwargs)
+
     skip_iterations = cf_solving.get("skip_iterations", False)
     if not n.lines.s_nom_extendable.any():
         skip_iterations = True

--- a/scripts/solve_network.py
+++ b/scripts/solve_network.py
@@ -52,8 +52,8 @@ Total annual system costs are minimised with PyPSA. The full formulation of the
 linear optimal power flow (plus investment planning)
 is provided in the
 `documentation of PyPSA <https://pypsa.readthedocs.io/en/latest/optimal_power_flow.html#linear-optimal-power-flow>`_.
-The optimization is based on the ``pyomo=False`` setting in the :func:`network.lopf` and  :func:`pypsa.linopf.ilopf` function.
-Additionally, some extra constraints specified in :mod:`prepare_network` are added.
+The optimisation is based on the :func:`network.optimize` function.
+Additionally, some extra constraints specified in :mod:`prepare_network` and :mod:`solve_network` are added.
 
 Solving the network in multiple iterations is motivated through the dependence of transmission line capacities and impedances on values of corresponding flows.
 As lines are expanded their electrical parameters change, which renders the optimisation bilinear even if the power flow
@@ -83,6 +83,7 @@ import re
 import numpy as np
 import pandas as pd
 import pypsa
+import xarray as xr
 from _helpers import (
     build_directory,
     configure_logging,
@@ -90,17 +91,12 @@ from _helpers import (
     mock_snakemake,
     override_component_attrs,
 )
+from linopy import merge
 from pypsa.descriptors import get_switchable_as_dense as get_as_dense
-from pypsa.linopf import (
-    define_constraints,
-    define_variables,
-    get_var,
-    ilopf,
-    join_exprs,
-    linexpr,
-    network_lopf,
-)
 from pypsa.linopt import define_constraints, get_var, join_exprs, linexpr
+from pypsa.optimization.abstract import optimize_transmission_expansion_iteratively
+from pypsa.optimization.optimize import optimize
+from vresutils.benchmark import memory_logger
 
 logger = create_logger(__name__)
 pypsa.pf.logger.setLevel(logging.WARNING)
@@ -162,7 +158,24 @@ def prepare_network(n, solve_opts):
     return n
 
 
-def add_CCL_constraints(n, config):
+def add_ccl_constraints(n, config):
+    """
+    Add CCL (country & carrier limit) constraint to the network. Add minimum
+    and maximum levels of generator nominal capacity per carrier for individual
+    countries. Opts and path for agg_p_nom_minmax.csv must be defined in
+    config.yaml. Default file is available at data/agg_p_nom_minmax.csv.
+
+    Parameters
+    ----------
+    n : pypsa.Network
+    config : dict
+    Example
+    -------
+    scenario:
+        opts: [Co2L-CCL-24H]
+    electricity:
+        agg_p_nom_limits: data/agg_p_nom_minmax.csv
+    """
     agg_p_nom_limits = config["electricity"].get("agg_p_nom_limits")
 
     try:
@@ -178,32 +191,57 @@ def add_CCL_constraints(n, config):
     )
 
     gen_country = n.generators.bus.map(n.buses.country)
-    # cc means country and carrier
-    p_nom_per_cc = (
-        pd.DataFrame(
-            {
-                "p_nom": linexpr((1, get_var(n, "Generator", "p_nom"))),
-                "country": gen_country,
-                "carrier": n.generators.carrier,
-            }
+    capacity_variable = n.model["Generator-p_nom"]
+
+    lhs = []
+    ext_carriers = n.generators.query("p_nom_extendable").carrier.unique()
+    for c in ext_carriers:
+        ext_carrier = n.generators.query("p_nom_extendable and carrier == @c")
+        country_grouper = (
+            ext_carrier.bus.map(n.buses.country)
+            .rename_axis("Generator-ext")
+            .rename("country")
         )
-        .dropna(subset=["p_nom"])
-        .groupby(["country", "carrier"])
-        .p_nom.apply(join_exprs)
+        ext_carrier_per_country = capacity_variable.loc[
+            country_grouper.index
+        ].groupby_sum(country_grouper)
+        lhs.append(ext_carrier_per_country)
+    lhs = merge(lhs, dim=pd.Index(ext_carriers, name="carrier"))
+
+    min_matrix = agg_p_nom_minmax["min"].to_xarray().unstack().reindex_like(lhs)
+    max_matrix = agg_p_nom_minmax["max"].to_xarray().unstack().reindex_like(lhs)
+
+    n.model.add_constraints(
+        lhs >= min_matrix, name="agg_p_nom_min", mask=min_matrix.notnull()
     )
-    minimum = agg_p_nom_minmax["min"].dropna()
-    if not minimum.empty:
-        minconstraint = define_constraints(
-            n, p_nom_per_cc[minimum.index], ">=", minimum, "agg_p_nom", "min"
-        )
-    maximum = agg_p_nom_minmax["max"].dropna()
-    if not maximum.empty:
-        maxconstraint = define_constraints(
-            n, p_nom_per_cc[maximum.index], "<=", maximum, "agg_p_nom", "max"
-        )
+    n.model.add_constraints(
+        lhs <= max_matrix, name="agg_p_nom_max", mask=max_matrix.notnull()
+    )
 
 
-def add_EQ_constraints(n, o, scaling=1e-1):
+def add_eq_constraints(n, o, scaling=1e-1):
+    """
+    Add equity constraints to the network.
+
+    Currently, this is only implemented for the electricity sector only.
+
+    Opts must be specified in the config.yaml.
+
+    Parameters
+    ----------
+    n : pypsa.Network
+    o : str
+
+    Example
+    -------
+    scenario:
+        opts: [Co2L-EQ0.7-24h]
+
+    Require each country or node to on average produce a minimal share
+    of its total electricity consumption itself. Example: EQ0.7c demands each country
+    to produce on average at least 70% of its consumption; EQ0.7 demands
+    each node to produce on average at least 70% of its consumption.
+    """
     float_regex = "[0-9]*\.?[0-9]+"
     level = float(re.findall(float_regex, o)[0])
     if o[-1] == "c":
@@ -224,99 +262,148 @@ def add_EQ_constraints(n, o, scaling=1e-1):
     )
     inflow = inflow.reindex(load.index).fillna(0.0)
     rhs = scaling * (level * load - inflow)
+    dispatch_variable = n.model["Generator-p"]
     lhs_gen = (
-        linexpr(
-            (n.snapshot_weightings.generators * scaling, get_var(n, "Generator", "p").T)
+        (dispatch_variable * (n.snapshot_weightings.generators * scaling))
+        .groupby(ggrouper.to_xarray())
+        .sum()
+        .sum("snapshot")
+    )
+    # TODO: double check that this is really needed, why do have to subtract the spillage
+    if not n.storage_units_t.inflow.empty:
+        spillage_variable = n.model["StorageUnit-spill"]
+        lhs_spill = (
+            (spillage_variable * (-n.snapshot_weightings.stores * scaling))
+            .groupby_sum(sgrouper)
+            .groupby(sgrouper.to_xarray())
+            .sum()
+            .sum("snapshot")
         )
-        .T.groupby(ggrouper, axis=1)
-        .apply(join_exprs)
-    )
-    lhs_spill = (
-        linexpr(
-            (
-                -n.snapshot_weightings.stores * scaling,
-                get_var(n, "StorageUnit", "spill").T,
-            )
-        )
-        .T.groupby(sgrouper, axis=1)
-        .apply(join_exprs)
-    )
-    lhs_spill = lhs_spill.reindex(lhs_gen.index).fillna("")
-    lhs = lhs_gen + lhs_spill
-    define_constraints(n, lhs, ">=", rhs, "equity", "min")
+        lhs = lhs_gen + lhs_spill
+    else:
+        lhs = lhs_gen
+    n.model.add_constraints(lhs >= rhs, name="equity_min")
 
 
-def add_BAU_constraints(n, config):
-    ext_c = n.generators.query("p_nom_extendable").carrier.unique()
-    mincaps = pd.Series(
-        config["electricity"].get("BAU_mincapacities", {key: 0 for key in ext_c})
-    )
-    lhs = (
-        linexpr((1, get_var(n, "Generator", "p_nom")))
-        .groupby(n.generators.carrier)
-        .apply(join_exprs)
-    )
-    define_constraints(n, lhs, ">=", mincaps[lhs.index], "Carrier", "bau_mincaps")
+def add_bau_constraints(n, config):
+    """
+    Add a per-carrier minimal overall capacity. BAU_mincapacities and opts must
+    be adjusted in the config.yaml.
 
-    maxcaps = pd.Series(
-        config["electricity"].get("BAU_maxcapacities", {key: np.inf for key in ext_c})
-    )
-    lhs = (
-        linexpr((1, get_var(n, "Generator", "p_nom")))
-        .groupby(n.generators.carrier)
-        .apply(join_exprs)
-    )
-    define_constraints(n, lhs, "<=", maxcaps[lhs.index], "Carrier", "bau_maxcaps")
+    Parameters
+    ----------
+    n : pypsa.Network
+    config : dict
+    Example
+    -------
+    scenario:
+        opts: [Co2L-BAU-24h]
+    electricity:
+        BAU_mincapacities:
+            solar: 0
+            onwind: 0
+            OCGT: 100000
+            offwind-ac: 0
+            offwind-dc: 0
+    Which sets minimum expansion across all nodes e.g. in Europe to 100GW.
+    OCGT bus 1 + OCGT bus 2 + ... > 100000
+    """
+    mincaps = pd.Series(config["electricity"]["BAU_mincapacities"])
+    p_nom = n.model["Generator-p_nom"]
+    ext_i = n.generators.query("p_nom_extendable")
+    ext_carrier_i = xr.DataArray(ext_i.carrier.rename_axis("Generator-ext"))
+    lhs = p_nom.groupby(ext_carrier_i).sum()
+    rhs = mincaps[lhs.indexes["carrier"]].rename_axis("carrier")
+    n.model.add_constraints(lhs >= rhs, name="bau_mincaps")
 
 
-def add_SAFE_constraints(n, config):
-    peakdemand = (
-        1.0 + config["electricity"]["SAFE_reservemargin"]
-    ) * n.loads_t.p_set.sum(axis=1).max()
-    conv_techs = config["plotting"]["conv_techs"]
+def add_safe_constraints(n, config):
+    """
+    Add a capacity reserve margin of a certain fraction above the peak demand.
+    Renewable generators and storage do not contribute. Ignores network.
+
+    Parameters
+    ----------
+        n : pypsa.Network
+        config : dict
+
+    Example
+    -------
+    config.yaml requires to specify opts:
+
+    scenario:
+        opts: [Co2L-SAFE-24h]
+    electricity:
+        SAFE_reservemargin: 0.1
+    Which sets a reserve margin of 10% above the peak demand.
+    """
+    peakdemand = n.loads_t.p_set.sum(axis=1).max()
+    margin = 1.0 + config["electricity"]["SAFE_reservemargin"]
+    reserve_margin = peakdemand * margin
+    conventional_carriers = config["electricity"]["conventional_carriers"]
+    ext_gens_i = n.generators.query(
+        "carrier in @conventional_carriers & p_nom_extendable"
+    ).index
+    capacity_variable = n.model["Generator-p_nom"]
+    p_nom = n.model["Generator-p_nom"].loc[ext_gens_i]
+    lhs = p_nom.sum()
     exist_conv_caps = n.generators.query(
-        "~p_nom_extendable & carrier in @conv_techs"
+        "~p_nom_extendable & carrier in @conventional_carriers"
     ).p_nom.sum()
-    ext_gens_i = n.generators.query("carrier in @conv_techs & p_nom_extendable").index
-    lhs = linexpr((1, get_var(n, "Generator", "p_nom")[ext_gens_i])).sum()
-    rhs = peakdemand - exist_conv_caps
-    define_constraints(n, lhs, ">=", rhs, "Safe", "mintotalcap")
+    rhs = reserve_margin - exist_conv_caps
+    n.model.add_constraints(lhs >= rhs, name="safe_mintotalcap")
 
 
-def add_operational_reserve_margin_constraint(n, config):
+def add_operational_reserve_margin_constraint(n, sns, config):
+    """
+    Build reserve margin constraints based on the formulation
+    as suggested in GenX
+    https://energy.mit.edu/wp-content/uploads/2017/10/Enhanced-Decision-Support-for-a-Changing-Electricity-Landscape.pdf
+    It implies that the reserve margin also accounts for optimal
+    dispatch of distributed energy resources (DERs) and demand response
+    which is a novel feature of GenX.
+    """
     reserve_config = config["electricity"]["operational_reserve"]
     EPSILON_LOAD = reserve_config["epsilon_load"]
     EPSILON_VRES = reserve_config["epsilon_vres"]
     CONTINGENCY = reserve_config["contingency"]
 
     # Reserve Variables
-    reserve = get_var(n, "Generator", "r")
-    lhs = linexpr((1, reserve)).sum(1)
+    n.model.add_variables(
+        0, np.inf, coords=[sns, n.generators.index], name="Generator-r"
+    )
+    reserve = n.model["Generator-r"]
+    lhs = reserve.sum("Generator")
 
     # Share of extendable renewable capacities
     ext_i = n.generators.query("p_nom_extendable").index
     vres_i = n.generators_t.p_max_pu.columns
     if not ext_i.empty and not vres_i.empty:
         capacity_factor = n.generators_t.p_max_pu[vres_i.intersection(ext_i)]
-        renewable_capacity_variables = get_var(n, "Generator", "p_nom")[
-            vres_i.intersection(ext_i)
-        ]
-        lhs += linexpr(
-            (-EPSILON_VRES * capacity_factor, renewable_capacity_variables)
-        ).sum(1)
+        renewable_capacity_variables = (
+            n.model["Generator-p_nom"]
+            .loc[vres_i.intersection(ext_i)]
+            .rename({"Generator-ext": "Generator"})
+        )
+        lhs = merge(
+            lhs,
+            (renewable_capacity_variables * (-EPSILON_VRES * capacity_factor)).sum(
+                ["Generator"]
+            ),
+        )
 
-    # Total demand at t
-    demand = n.loads_t.p.sum(1)
+    # Total demand per t
+    demand = get_as_dense(n, "Load", "p_set").sum(axis=1)
 
-    # VRES potential of non extendable generators
+    # VRES potential of non-extendable generators
     capacity_factor = n.generators_t.p_max_pu[vres_i.difference(ext_i)]
     renewable_capacity = n.generators.p_nom[vres_i.difference(ext_i)]
-    potential = (capacity_factor * renewable_capacity).sum(1)
+    potential = (capacity_factor * renewable_capacity).sum(axis=1)
 
     # Right-hand-side
     rhs = EPSILON_LOAD * demand + EPSILON_VRES * potential + CONTINGENCY
 
-    define_constraints(n, lhs, ">=", rhs, "Reserve margin")
+    n.model.add_constraints(lhs >= rhs, name="reserve_margin")
 
 
 def update_capacity_constraint(n):
@@ -324,65 +411,80 @@ def update_capacity_constraint(n):
     ext_i = n.generators.query("p_nom_extendable").index
     fix_i = n.generators.query("not p_nom_extendable").index
 
-    dispatch = get_var(n, "Generator", "p")
-    reserve = get_var(n, "Generator", "r")
+    dispatch = n.model["Generator-p"]
+    reserve = n.model["Generator-r"]
 
     capacity_fixed = n.generators.p_nom[fix_i]
 
     p_max_pu = get_as_dense(n, "Generator", "p_max_pu")
 
-    lhs = linexpr((1, dispatch), (1, reserve))
+    lhs = merge(
+        dispatch * 1,
+        reserve * 1,
+    )
 
     if not ext_i.empty:
-        capacity_variable = get_var(n, "Generator", "p_nom")
-        lhs += linexpr((-p_max_pu[ext_i], capacity_variable)).reindex(
-            columns=gen_i, fill_value=""
-        )
+        capacity_variable = n.model["Generator-p_nom"]
+        lhs = dispatch + reserve - capacity_variable * xr.DataArray(p_max_pu[ext_i])
 
     rhs = (p_max_pu[fix_i] * capacity_fixed).reindex(columns=gen_i, fill_value=0)
-
-    define_constraints(n, lhs, "<=", rhs, "Generators", "updated_capacity_constraint")
+    n.model.add_constraints(
+        lhs <= rhs, name="gen_updated_capacity_constraint", mask=rhs.notnull()
+    )
 
 
 def add_operational_reserve_margin(n, sns, config):
     """
-    Build reserve margin constraints based on the formulation given in
-    https://genxproject.github.io/GenX/dev/core/#Reserves.
+        Build reserve margin constraints based on the formulation given in
+        https://genxproject.github.io/GenX/dev/core/#Reserves.
+    Parameters
+        ----------
+            n : pypsa.Network
+            sns: pd.DatetimeIndex
+            config : dict
+        Example:
+        --------
+        config.yaml requires to specify operational_reserve:
+        operational_reserve: # like https://genxproject.github.io/GenX/dev/core/#Reserves
+            activate: true
+            epsilon_load: 0.02 # percentage of load at each snapshot
+            epsilon_vres: 0.02 # percentage of VRES at each snapshot
+            contingency: 400000 # MW
     """
-
-    define_variables(n, 0, np.inf, "Generator", "r", axes=[sns, n.generators.index])
-
-    add_operational_reserve_margin_constraint(n, config)
-
+    add_operational_reserve_margin_constraint(n, sns, config)
     update_capacity_constraint(n)
 
 
 def add_battery_constraints(n):
+    """
+    Add constraint ensuring that charger = discharger, i.e.
+    1 * charger_size - efficiency * discharger_size = 0
+    """
     nodes = n.buses.index[n.buses.carrier == "battery"]
-    if nodes.empty or ("Link", "p_nom") not in n.variables.index:
+    # if nodes.empty or ("Link", "p_nom") not in n.variables.index:
+    if nodes.empty:
         return
-    link_p_nom = get_var(n, "Link", "p_nom")
-    lhs = linexpr(
-        (1, link_p_nom[nodes + " charger"]),
-        (
-            -n.links.loc[nodes + " discharger", "efficiency"].values,
-            link_p_nom[nodes + " discharger"].values,
-        ),
+    vars_link = n.model["Link-p_nom"]
+    eff = n.links.loc[nodes + " discharger", "efficiency"]
+    lhs = merge(
+        vars_link.sel({"Link-ext": nodes + " charger"}) * 1,
+        # for some reason, eff is one element longer as compared with vars_link
+        vars_link.sel({"Link-ext": nodes + " discharger"}) * -eff[0],
     )
-    define_constraints(n, lhs, "=", 0, "Link", "charger_ratio")
+    n.model.add_constraints(lhs == 0, name="link_charger_ratio")
 
 
-def add_RES_constraints(n, res_share):
+def add_res_constraints(n, res_share, config):
     lgrouper = n.loads.bus.map(n.buses.country)
     ggrouper = n.generators.bus.map(n.buses.country)
     sgrouper = n.storage_units.bus.map(n.buses.country)
     cgrouper = n.links.bus0.map(n.buses.country)
 
     logger.warning(
-        "The add_RES_constraints functionality is still work in progress. "
+        "The add_RES_constraints() is still work in progress. "
         "Unexpected results might be incurred, particularly if "
         "temporal clustering is applied or if an unexpected change of technologies "
-        "is subject to the obtimisation."
+        "is subject to the obpimisation."
     )
 
     load = (
@@ -392,15 +494,7 @@ def add_RES_constraints(n, res_share):
 
     rhs = res_share * load
 
-    res_techs = [
-        "solar",
-        "onwind",
-        "offwind-dc",
-        "offwind-ac",
-        "battery",
-        "hydro",
-        "ror",
-    ]
+    renew_techs = config["electricity"]["renewable_carriers"]
     charger = ["H2 electrolysis", "battery charger"]
     discharger = ["H2 fuel cell", "battery discharger"]
 
@@ -861,7 +955,7 @@ def add_existing(n):
 def extra_functionality(n, snapshots):
     """
     Collects supplementary constraints which will be passed to
-    ``pypsa.linopf.network_lopf``.
+    ``pypsa.optimization.optimize``.
 
     If you want to enforce additional custom constraints, this is a good location to add them.
     The arguments ``opts`` and ``snakemake.config`` are expected to be attached to the network.
@@ -869,21 +963,21 @@ def extra_functionality(n, snapshots):
     opts = n.opts
     config = n.config
     if "BAU" in opts and n.generators.p_nom_extendable.any():
-        add_BAU_constraints(n, config)
+        add_bau_constraints(n, config)
     if "SAFE" in opts and n.generators.p_nom_extendable.any():
-        add_SAFE_constraints(n, config)
+        add_safe_constraints(n, config)
     if "CCL" in opts and n.generators.p_nom_extendable.any():
-        add_CCL_constraints(n, config)
+        add_ccl_constraints(n, config)
     reserve = config["electricity"].get("operational_reserve", {})
     if reserve.get("activate"):
         add_operational_reserve_margin(n, snapshots, config)
     for o in opts:
         if "RES" in o:
             res_share = float(re.findall("[0-9]*\.?[0-9]+$", o)[0])
-            add_RES_constraints(n, res_share)
+            add_res_constraints(n, res_share)
     for o in opts:
         if "EQ" in o:
-            add_EQ_constraints(n, o)
+            add_eq_constraints(n, o)
     add_battery_constraints(n)
 
     if (
@@ -931,40 +1025,42 @@ def extra_functionality(n, snapshots):
     add_co2_sequestration_limit(n, snapshots)
 
 
-def solve_network(n, config, solving={}, opts="", **kwargs):
+def solve_network(n, config, solving={}, **kwargs):
     set_of_options = solving["solver"]["options"]
     cf_solving = solving["options"]
 
-    solver_options = solving["solver_options"][set_of_options] if set_of_options else {}
-    solver_name = solving["solver"]["name"]
-
-    track_iterations = cf_solving.get("track_iterations", False)
-    min_iterations = cf_solving.get("min_iterations", 4)
-    max_iterations = cf_solving.get("max_iterations", 6)
+    kwargs["solver_options"] = (
+        solving["solver_options"][set_of_options] if set_of_options else {}
+    )
+    kwargs["solver_name"] = solving["solver"]["name"]
+    skip_iterations = cf_solving.get("skip_iterations", False)
+    if not n.lines.s_nom_extendable.any():
+        skip_iterations = True
+        logger.info("No expandable lines found. Skipping iterative solving.")
 
     # add to network for extra_functionality
     n.config = config
-    n.opts = opts
 
-    if cf_solving.get("skip_iterations", False):
-        network_lopf(
-            n,
-            solver_name=solver_name,
-            solver_options=solver_options,
-            extra_functionality=extra_functionality,
-            **kwargs,
-        )
+    if skip_iterations:
+        status, condition = n.optimize(**kwargs)
     else:
-        ilopf(
-            n,
-            solver_name=solver_name,
-            solver_options=solver_options,
-            track_iterations=track_iterations,
-            min_iterations=min_iterations,
-            max_iterations=max_iterations,
-            extra_functionality=extra_functionality,
-            **kwargs,
+        kwargs["track_iterations"] = (cf_solving.get("track_iterations", False),)
+        kwargs["min_iterations"] = (cf_solving.get("min_iterations", 4),)
+        kwargs["max_iterations"] = (cf_solving.get("max_iterations", 6),)
+        status, condition = n.optimize.optimize_transmission_expansion_iteratively(
+            **kwargs
         )
+
+    if status != "ok":  # and not rolling_horizon:
+        logger.warning(
+            f"Solving status '{status}' with termination condition '{condition}'"
+        )
+    if "infeasible" in condition:
+        labels = n.model.compute_infeasibilities()
+        logger.info(f"Labels:\n{labels}")
+        n.model.print_infeasibilities()
+        raise RuntimeError("Solving status 'infeasible'")
+
     return n
 
 
@@ -1024,7 +1120,6 @@ if __name__ == "__main__":
         n,
         config=snakemake.config,
         solving=solving,
-        opts=opts,
         solver_dir=tmpdir,
         solver_logfile=snakemake.log.solver,
     )

--- a/scripts/solve_network.py
+++ b/scripts/solve_network.py
@@ -975,6 +975,7 @@ def solve_network(n, config, solving={}, **kwargs):
     kwargs["extra_functionality"] = extra_functionality
 
     logger.info("kwargs", kwargs)
+    print("kwargs {}".format(kwargs))
 
     skip_iterations = cf_solving.get("skip_iterations", False)
     if not n.lines.s_nom_extendable.any():


### PR DESCRIPTION
# Closes # (if applicable).

## Changes proposed in this Pull Request

#### Change

`_make_consense is deprecated` --> replaced with `make_consense`

#### Change
`pypsa.clustering.spatial.aggregategenerators` is deprecated --> replaced it with `pypsa.clustering.spatial.aggregateoneport` as described in [PyPSA](https://github.com/PyPSA/PyPSA/commit/f1ecd42aa97761f4d5606203c14294d8d1133730). 

Namely: 
```
 @deprecated(details="Use `aggregateoneport` instead.")
def aggregategenerators(
    n,
    busmap,
    carriers=None,
    buses=None,
    with_time=True,
    custom_strategies=dict(),
):
    return aggregateoneport(
        n, busmap, "Generator", carriers, buses, with_time, custom_strategies
    )

```

#### Change

`scripts/build_shapes.py: in def save_to_geojson() modify df.to_file(fn, driver="GeoJSON", schema=schema) --> df.to_file(fn, driver="GeoJSON")`. This is due to the error

```
ERROR:_helpers:An error happened in module '/home/runner/micromamba/envs/pypsa-earth/lib/python3.10/site-packages/geopandas/io/file.py', function '_to_file_pyogrio': The 'schema' argument is not supported with the 'pyogrio' engine.
Traceback (most recent call last):
  File "/home/runner/work/pypsa-earth/pypsa-earth/.snakemake/scripts/tmpbcubb45o.build_shapes.py", line 1202, in <module>
    save_to_geojson(gadm_shapes, out.gadm_shapes)
  File "/home/runner/work/pypsa-earth/pypsa-earth/.snakemake/scripts/tmpbcubb45o.build_shapes.py", line 131, in save_to_geojson
    df.to_file(fn, driver="GeoJSON", schema=schema)
  File "/home/runner/micromamba/envs/pypsa-earth/lib/python3.10/site-packages/geopandas/geodataframe.py", line 1536, in to_file
    _to_file(self, filename, driver, schema, index, **kwargs)
  File "/home/runner/micromamba/envs/pypsa-earth/lib/python3.10/site-packages/geopandas/io/file.py", line 686, in _to_file
    _to_file_pyogrio(df, filename, driver, schema, crs, mode, metadata, **kwargs)
  File "/home/runner/micromamba/envs/pypsa-earth/lib/python3.10/site-packages/geopandas/io/file.py", line 734, in _to_file_pyogrio
    raise ValueError(
ValueError: The 'schema' argument is not supported with the 'pyogrio' engine.
```

#### Change
Modify `scripts/simplify_network.py` and `scripts/cluster_network.py` as shown [here](https://github.com/pypsa-meets-earth/pypsa-earth/pull/1065/files). These changes are needed due to errors like

```
Traceback (most recent call last):
  File "/home/runner/work/pypsa-earth/pypsa-earth/.snakemake/scripts/tmp2xmhxgdg.cluster_network.py", line 743, in <module>
    clustering = clustering_for_n_clusters(
  File "/home/runner/work/pypsa-earth/pypsa-earth/.snakemake/scripts/tmp2xmhxgdg.cluster_network.py", line 602, in clustering_for_n_clusters
    clustering = get_clustering_from_busmap(
  File "/home/runner/micromamba/envs/pypsa-earth/lib/python3.10/site-packages/pypsa/clustering/spatial.py", line 475, in get_clustering_from_busmap
    buses = aggregatebuses(n, busmap, custom_strategies=bus_strategies)
  File "/home/runner/micromamba/envs/pypsa-earth/lib/python3.10/site-packages/pypsa/clustering/spatial.py", line 320, in aggregatebuses
    aggregated = n.buses.groupby(busmap).agg(strategies)
  File "/home/runner/micromamba/envs/pypsa-earth/lib/python3.10/site-packages/pandas/core/groupby/generic.py", line 1432, in aggregate
    result = op.agg()
  File "/home/runner/micromamba/envs/pypsa-earth/lib/python3.10/site-packages/pandas/core/apply.py", line 190, in agg
    return self.agg_dict_like()
  File "/home/runner/micromamba/envs/pypsa-earth/lib/python3.10/site-packages/pandas/core/apply.py", line 423, in agg_dict_like
    return self.agg_or_apply_dict_like(op_name="agg")
  File "/home/runner/micromamba/envs/pypsa-earth/lib/python3.10/site-packages/pandas/core/apply.py", line 1608, in agg_or_apply_dict_like
    result_index, result_data = self.compute_dict_like(
  File "/home/runner/micromamba/envs/pypsa-earth/lib/python3.10/site-packages/pandas/core/apply.py", line 496, in compute_dict_like
    results = [
  File "/home/runner/micromamba/envs/pypsa-earth/lib/python3.10/site-packages/pandas/core/apply.py", line 497, in <listcomp>
    getattr(obj._gotitem(key, ndim=1), op_name)(how, **kwargs)
  File "/home/runner/micromamba/envs/pypsa-earth/lib/python3.10/site-packages/pandas/core/groupby/generic.py", line 294, in aggregate
    return self._python_agg_general(func, *args, **kwargs)
  File "/home/runner/micromamba/envs/pypsa-earth/lib/python3.10/site-packages/pandas/core/groupby/generic.py", line 327, in _python_agg_general
    result = self._grouper.agg_series(obj, f)
  File "/home/runner/micromamba/envs/pypsa-earth/lib/python3.10/site-packages/pandas/core/groupby/ops.py", line 864, in agg_series
    result = self._aggregate_series_pure_python(obj, func)
  File "/home/runner/micromamba/envs/pypsa-earth/lib/python3.10/site-packages/pandas/core/groupby/ops.py", line 885, in _aggregate_series_pure_python
    res = func(group)
  File "/home/runner/micromamba/envs/pypsa-earth/lib/python3.10/site-packages/pandas/core/groupby/generic.py", line 324, in <lambda>
    f = lambda x: func(x, *args, **kwargs)
  File "/home/runner/micromamba/envs/pypsa-earth/lib/python3.10/site-packages/pypsa/clustering/spatial.py", line 132, in consense
    assert (x == v).all() or x.isnull().all(), (
AssertionError: In Bus cluster lon, the values of attribute lon do not agree:
Bus
113    5.9359
114    6.1549
118    5.5912
121    5.7840
125    7.5462
127    8.4887
132    6.3849
16     7.6804
183    6.9449
29     5.6430
36     6.6291
42     6.1971
44     7.3236
56     5.6401
6      6.6576
60     8.5706
64     6.2174
65     6.3678
76     5.7980
88     7.2388
94     6.8198
```

## Checklist

- [ ] I consent to the release of this PR's code under the AGPLv3 license and non-code contributions under CC0-1.0 and CC-BY-4.0.
- [ ] I tested my contribution locally and it seems to work fine.
- [ ] Code and workflow changes are sufficiently documented.
- [ ] Newly introduced dependencies are added to `envs/environment.yaml` and `doc/requirements.txt`.
- [ ] Changes in configuration options are added in all of `config.default.yaml` and `config.tutorial.yaml`.
- [ ] Add a test config or line additions to `test/` (note tests are changing the config.tutorial.yaml)
- [ ] Changes in configuration options are also documented in `doc/configtables/*.csv` and line references are adjusted in `doc/configuration.rst` and `doc/tutorial.rst`.
- [ ] A note for the release notes `doc/release_notes.rst` is amended in the format of previous release notes, including reference to the requested PR.
