### PR TITLE
Fix bugs in prepare_sector_network to address issues with respect to demands

### DIFF
--- a/doc/release_notes.rst
+++ b/doc/release_notes.rst
@@ -25,6 +25,8 @@ This part of documentation collects descriptive release notes to capture the mai
 
 * Fix readthedocs by explicitly specifying the location of the Sphinx config `PR #1292 <https://github.com/pypsa-meets-earth/pypsa-earth/pull/1292>`__
 
+* Fix bugs in demand scaling in the sector-coupled model `PR #24 <https://github.com/open-energy-transition/pypsa-earth/pull/24>`__
+
 PyPSA-Earth 0.6.0
 =================
 

--- a/scripts/prepare_sector_network.py
+++ b/scripts/prepare_sector_network.py
@@ -2311,7 +2311,7 @@ def add_dac(n, costs):
 
 
 def add_services(n, costs):
-    nhours = n.snapshot_weightings.generators.sum()
+    temporal_resolution = n.snapshot_weightings.generators.iloc[0]
     buses = spatial.nodes.intersection(n.loads_t.p_set.columns)
 
     profile_residential = normalize_by_country(
@@ -2319,7 +2319,7 @@ def add_services(n, costs):
     ).fillna(0)
 
     p_set_elec = p_set_from_scaling(
-        "services electricity", profile_residential, energy_totals, nhours
+        "services electricity", profile_residential, energy_totals, temporal_resolution
     )
 
     n.madd(
@@ -2331,7 +2331,7 @@ def add_services(n, costs):
         p_set=p_set_elec,
     )
     p_set_biomass = p_set_from_scaling(
-        "services biomass", profile_residential, energy_totals, nhours
+        "services biomass", profile_residential, energy_totals, temporal_resolution
     )
 
     n.madd(
@@ -2355,7 +2355,7 @@ def add_services(n, costs):
     #     p_set=-co2,
     # )
     p_set_oil = p_set_from_scaling(
-        "services oil", profile_residential, energy_totals, nhours
+        "services oil", profile_residential, energy_totals, temporal_resolution
     )
 
     n.madd(
@@ -2379,7 +2379,7 @@ def add_services(n, costs):
     )
 
     p_set_gas = p_set_from_scaling(
-        "services gas", profile_residential, energy_totals, nhours
+        "services gas", profile_residential, energy_totals, temporal_resolution
     )
 
     n.madd(
@@ -2492,7 +2492,7 @@ def add_residential(n, costs):
     # heat_demand_index=n.loads_t.p.filter(like='residential').filter(like='heat').dropna(axis=1).index
     # oil_res_index=n.loads_t.p.filter(like='residential').filter(like='oil').dropna(axis=1).index
 
-    nhours = n.snapshot_weightings.generators.sum()
+    temporal_resolution = n.snapshot_weightings.generators.iloc[0]
 
     heat_ind = (
         n.loads_t.p_set.filter(like="residential")
@@ -2513,17 +2513,17 @@ def add_residential(n, costs):
         - energy_totals["residential heat oil"]
         - energy_totals["residential heat gas"],
         level=0,
-    ).droplevel(level=0, axis=1).div(nhours)
+    ).droplevel(level=0, axis=1).div(temporal_resolution)
 
     heat_oil_demand = p_set_from_scaling(
-        "residential heat oil", heat_shape, energy_totals, nhours
+        "residential heat oil", heat_shape, energy_totals, temporal_resolution
     )
     heat_biomass_demand = p_set_from_scaling(
-        "residential heat biomass", heat_shape, energy_totals, nhours
+        "residential heat biomass", heat_shape, energy_totals, temporal_resolution
     )
 
     heat_gas_demand = p_set_from_scaling(
-        "residential heat gas", heat_shape, energy_totals, nhours
+        "residential heat gas", heat_shape, energy_totals, temporal_resolution
     )
 
     res_index = spatial.nodes.intersection(n.loads_t.p_set.columns)
@@ -2535,21 +2535,24 @@ def add_residential(n, costs):
 
     p_set_oil = (
         p_set_from_scaling(
-            "residential oil", profile_residential, energy_totals, nhours
+            "residential oil", profile_residential, energy_totals, temporal_resolution
         )
         + heat_oil_demand
     )
 
     p_set_biomass = (
         p_set_from_scaling(
-            "residential biomass", profile_residential, energy_totals, nhours
+            "residential biomass",
+            profile_residential,
+            energy_totals,
+            temporal_resolution,
         )
         + heat_biomass_demand
     )
 
     p_set_gas = (
         p_set_from_scaling(
-            "residential gas", profile_residential, energy_totals, nhours
+            "residential gas", profile_residential, energy_totals, temporal_resolution
         )
         + heat_gas_demand
     )
@@ -2619,7 +2622,7 @@ def add_residential(n, costs):
         )
         n.loads_t.p_set.loc[:, heat_buses] = np.where(
             ~np.isnan(safe_division),
-            safe_division * rem_heat_demand * 1e6 / nhours,
+            safe_division * rem_heat_demand * 1e6 / temporal_resolution,
             0.0,
         )
 
@@ -2628,7 +2631,7 @@ def add_residential(n, costs):
 
     profile_pu = normalize_by_country(n.loads_t.p_set[buses]).fillna(0)
     n.loads_t.p_set.loc[:, buses] = p_set_from_scaling(
-        "electricity residential", profile_pu, energy_totals, nhours
+        "electricity residential", profile_pu, energy_totals, temporal_resolution
     )
 
 

--- a/scripts/prepare_sector_network.py
+++ b/scripts/prepare_sector_network.py
@@ -2626,6 +2626,11 @@ def add_residential(n, costs):
 
     # Revise residential electricity demand
     buses = n.buses[n.buses.carrier == "AC"].index.intersection(n.loads_t.p_set.columns)
+    
+    # Removing static loads from the time varying demand to preserve the distribution profile afer normalization
+    static_load = n.loads.query('carrier.str.contains("electricity")').groupby('bus').p_set.sum()
+    n.loads_t.p_set.loc[:,buses] -= static_load
+    n.loads_t.p_set.loc[:,buses] = n.loads_t.p_set.loc[:, buses].clip(lower=0)
 
     profile_pu = normalize_by_country(n.loads_t.p_set[buses]).fillna(0)
     n.loads_t.p_set.loc[:, buses] = p_set_from_scaling(

--- a/scripts/prepare_sector_network.py
+++ b/scripts/prepare_sector_network.py
@@ -2478,9 +2478,8 @@ def p_set_from_scaling(col, scaling, energy_totals, nhours):
     Function to create p_set from energy_totals, using the per-unit scaling
     dataframe.
     """
-    return (
-        1e6
-        * scaling.div(nhours,level=0).mul(energy_totals[col], level=0).droplevel(level=0, axis=1)
+    return 1e6 * scaling.div(nhours, axis=0).mul(energy_totals[col], level=0).droplevel(
+        level=0, axis=1
     )
 
 
@@ -2512,7 +2511,7 @@ def add_residential(n, costs):
         - energy_totals["residential heat oil"]
         - energy_totals["residential heat gas"],
         level=0,
-    ).droplevel(level=0, axis=1).div(temporal_resolution)
+    ).droplevel(level=0, axis=1).div(temporal_resolution, axis=0)
 
     heat_oil_demand = p_set_from_scaling(
         "residential heat oil", heat_shape, energy_totals, temporal_resolution
@@ -2621,7 +2620,7 @@ def add_residential(n, costs):
         )
         n.loads_t.p_set.loc[:, heat_buses] = np.where(
             ~np.isnan(safe_division),
-            safe_division * rem_heat_demand * 1e6 / temporal_resolution,
+            (safe_division * rem_heat_demand * 1e6).div(temporal_resolution, axis=0),
             0.0,
         )
 

--- a/scripts/prepare_sector_network.py
+++ b/scripts/prepare_sector_network.py
@@ -2311,7 +2311,7 @@ def add_dac(n, costs):
 
 
 def add_services(n, costs):
-    temporal_resolution = n.snapshot_weightings.generators.iloc[0]
+    temporal_resolution = n.snapshot_weightings.generators
     buses = spatial.nodes.intersection(n.loads_t.p_set.columns)
 
     profile_residential = normalize_by_country(
@@ -2480,8 +2480,7 @@ def p_set_from_scaling(col, scaling, energy_totals, nhours):
     """
     return (
         1e6
-        / nhours
-        * scaling.mul(energy_totals[col], level=0).droplevel(level=0, axis=1)
+        * scaling.div(nhours,level=0).mul(energy_totals[col], level=0).droplevel(level=0, axis=1)
     )
 
 
@@ -2492,7 +2491,7 @@ def add_residential(n, costs):
     # heat_demand_index=n.loads_t.p.filter(like='residential').filter(like='heat').dropna(axis=1).index
     # oil_res_index=n.loads_t.p.filter(like='residential').filter(like='oil').dropna(axis=1).index
 
-    temporal_resolution = n.snapshot_weightings.generators.iloc[0]
+    temporal_resolution = n.snapshot_weightings.generators
 
     heat_ind = (
         n.loads_t.p_set.filter(like="residential")

--- a/scripts/prepare_sector_network.py
+++ b/scripts/prepare_sector_network.py
@@ -2627,7 +2627,7 @@ def add_residential(n, costs):
     # Revise residential electricity demand
     buses = n.buses[n.buses.carrier == "AC"].index.intersection(n.loads_t.p_set.columns)
 
-    # Removing static loads from the time varying demand to preserve the distribution profile afer normalization
+    # Removing static loads from the time varying demand to preserve the distribution profile after normalization
     static_load = (
         n.loads.query('carrier.str.contains("electricity")').groupby("bus").p_set.sum()
     )

--- a/scripts/prepare_sector_network.py
+++ b/scripts/prepare_sector_network.py
@@ -2626,11 +2626,13 @@ def add_residential(n, costs):
 
     # Revise residential electricity demand
     buses = n.buses[n.buses.carrier == "AC"].index.intersection(n.loads_t.p_set.columns)
-    
+
     # Removing static loads from the time varying demand to preserve the distribution profile afer normalization
-    static_load = n.loads.query('carrier.str.contains("electricity")').groupby('bus').p_set.sum()
-    n.loads_t.p_set.loc[:,buses] -= static_load
-    n.loads_t.p_set.loc[:,buses] = n.loads_t.p_set.loc[:, buses].clip(lower=0)
+    static_load = (
+        n.loads.query('carrier.str.contains("electricity")').groupby("bus").p_set.sum()
+    )
+    n.loads_t.p_set.loc[:, buses] -= static_load
+    n.loads_t.p_set.loc[:, buses] = n.loads_t.p_set.loc[:, buses].clip(lower=0)
 
     profile_pu = normalize_by_country(n.loads_t.p_set[buses]).fillna(0)
     n.loads_t.p_set.loc[:, buses] = p_set_from_scaling(


### PR DESCRIPTION
# Closes # (if applicable).

## Changes proposed in this Pull Request
This PR has been made to address bugs to calculate sectoral demands

- [x] Conversion of energy totals using `temporal_resolution` instead of `nhours`
- [x] Removal of static load components prior to normalization of the demand profies. This helps conserve the shape of the profile before and after scaling based on energy_totals 

## Checklist

- [x] I consent to the release of this PR's code under the AGPLv3 license and non-code contributions under CC0-1.0 and CC-BY-4.0.
- [x] I tested my contribution locally and it seems to work fine.
- [x] Code and workflow changes are sufficiently documented.
- [ ] Newly introduced dependencies are added to `envs/environment.yaml` and `doc/requirements.txt`.
- [ ] Changes in configuration options are added in all of `config.default.yaml` and `config.tutorial.yaml`.
- [ ] Add a test config or line additions to `test/` (note tests are changing the config.tutorial.yaml)
- [ ] Changes in configuration options are also documented in `doc/configtables/*.csv` and line references are adjusted in `doc/configuration.rst` and `doc/tutorial.rst`.
- [ ] A note for the release notes `doc/release_notes.rst` is amended in the format of previous release notes, including reference to the requested PR.
