### PR TITLE
Disable implicit calculations of industry demands for steel and cement

### DIFF
--- a/scripts/build_industry_demand.py
+++ b/scripts/build_industry_demand.py
@@ -313,6 +313,26 @@ if __name__ == "__main__":
             )
             industry_base_totals.drop(columns=other_cols, inplace=True)
 
+        # Set coal, electricity, and gas to 0 for cement and iron and steel industry (because it is explicitly modeled)
+        for country in countries:
+            if snakemake.config.get("custom_industry",{}).get("steel", False):
+                industry_base_totals.loc[(country, "coal"), "iron and steel"] = 0.0
+                industry_base_totals.loc[(country, "electricity"), "iron and steel"] = 0.0
+                industry_base_totals.loc[(country, "gas"), "iron and steel"] = 0.0
+                industry_base_totals.loc[(country, "process emissions"), "iron and steel"] = 0.0
+                _logger.info(
+                    "Custom steel industry demand enabled. Setting coal, electricity, and gas to 0 for iron and steel industry."
+                )
+
+            if snakemake.config.get("custom_industry",{}).get("cement", False):
+                industry_base_totals.loc[(country, "electricity"), "non-metallic minerals"] = 0.0
+                industry_base_totals.loc[(country, "gas"), "non-metallic minerals"] = 0.0
+                industry_base_totals.loc[(country, "process emissions"), "non-metallic minerals"] = 0.0
+                _logger.info(
+                    "Custom cement industry demand enabled. Setting coal, electricity, and gas to 0 for cement industry."
+                )
+
+
         nodal_df = pd.DataFrame()
 
         for country in countries:


### PR DESCRIPTION
## Changes proposed in this Pull Request
Good day. This PR aims to disable implicit calculations of industry demands for steel and cement industries, because those industries are explicitly modelled in `efuels-supply-potentials` repository.

## Checklist

- [x] I consent to the release of this PR's code under the AGPLv3 license and non-code contributions under CC0-1.0 and CC-BY-4.0.
- [x] I tested my contribution locally and it seems to work fine.
- [ ] A note for the release notes `doc/release_notes.rst` is amended in the format of previous release notes, including reference to the requested PR.
