### PR TITLE
code: Extend powerplant filtering for custom powerplants (#1465)

### DIFF
--- a/doc/release_notes.rst
+++ b/doc/release_notes.rst
@@ -39,6 +39,8 @@ This part of documentation collects descriptive release notes to capture the mai
 
 * Revise naming of Wikipedia data for vehicles `PR #1422 <https://github.com/pypsa-meets-earth/pypsa-earth/pull/1422>`__
 
+* Extending powerplant filter option to custom powerplants `PR #1465 <https://github.com/pypsa-meets-earth/pypsa-earth/pull/1465>`__
+
 PyPSA-Earth 0.6.0
 =================
 

--- a/scripts/build_powerplants.py
+++ b/scripts/build_powerplants.py
@@ -348,8 +348,8 @@ if __name__ == "__main__":
     else:
         ppl = pd.DataFrame()
 
-    ppl = add_custom_powerplants(
-        ppl, snakemake.input, snakemake.config
+    ppl = add_custom_powerplants(ppl, snakemake.input, snakemake.config).query(
+        ppl_query
     )  # add carriers from own powerplant files
 
     cntries_without_ppl = [c for c in countries_codes if c not in ppl.Country.unique()]


### PR DESCRIPTION
## Changes proposed in this Pull Request
Good day. This PR cherry-picks the extensions of powerplants filtering introduced in [PR #1465](https://github.com/pypsa-meets-earth/pypsa-earth/pull/1465) to branch `efuels-supply-potentials`.

## Checklist

- [x] I consent to the release of this PR's code under the AGPLv3 license and non-code contributions under CC0-1.0 and CC-BY-4.0.
- [x] I tested my contribution locally and it seems to work fine.
- [x] A note for the release notes `doc/release_notes.rst` is amended in the format of previous release notes, including reference to the requested PR.
