### PR TITLE
Adjusts no_years for 2023 scenario

### DIFF
--- a/scripts/build_base_industry_totals.py
+++ b/scripts/build_base_industry_totals.py
@@ -108,6 +108,10 @@ if __name__ == "__main__":
     no_years = int(snakemake.wildcards.planning_horizons) - int(
         snakemake.params.base_year
     )
+
+    if int(snakemake.wildcards.planning_horizons) == 2020:
+        no_years = 2023 - int(snakemake.params.base_year)
+
     include_other = snakemake.params.other_industries
 
     transaction = read_csv_nafix(

--- a/scripts/prepare_energy_totals.py
+++ b/scripts/prepare_energy_totals.py
@@ -66,6 +66,10 @@ if __name__ == "__main__":
     no_years = int(snakemake.wildcards.planning_horizons) - int(
         snakemake.params.base_year
     )
+
+    if int(snakemake.wildcards.planning_horizons) == 2020:
+        no_years = 2023 - int(snakemake.params.base_year)
+
     growth_factors = calculate_end_values(growth_factors_cagr)
     efficiency_gains = calculate_end_values(efficiency_gains_cagr)
 


### PR DESCRIPTION
## Changes proposed in this Pull Request
Good day. This PR aims to adjust the calculation of `no_years` for 2023 scenario, because otherwise it causes improper calculation. Currently using `planning_horizon: 2023` would cause problems with costs, as costs for 2020 and 2025 are available, not 2023. Even though cost year is separated, still myopic run needs to take costs using planning_horizon.

## Checklist

- [x] I consent to the release of this PR's code under the AGPLv3 license and non-code contributions under CC0-1.0 and CC-BY-4.0.
- [x] I tested my contribution locally and it seems to work fine.
