### PR TITLE
Cherry pick fix to prepare_transport_data_input

### DIFF
--- a/doc/release_notes.rst
+++ b/doc/release_notes.rst
@@ -27,6 +27,8 @@ This part of documentation collects descriptive release notes to capture the mai
 
 **Minor Changes and bug-fixing**
 
+* Update code to reflect the Wikipedia source page for `prepare_transport_data_input`. `PR #1486 <https://github.com/pypsa-meets-earth/pypsa-earth/pull/1486>`__
+
 * Add efficiency gain and growth rates for other energy consumption and fill missing NaNs with 0. `PR #1468 <https://github.com/pypsa-meets-earth/pypsa-earth/pull/1468>`__
 
 * Fix problem with a discontinued World Bank data source in prepare_transport_data_input `PR #1410 <https://github.com/pypsa-meets-earth/pypsa-earth/pull/1410>`__

--- a/scripts/prepare_transport_data_input.py
+++ b/scripts/prepare_transport_data_input.py
@@ -89,7 +89,7 @@ def download_number_of_vehicles():
         vehicles_wiki = pd.DataFrame(columns=["Country", "country", "number cars"])
 
     vehicles_wiki.rename(
-        columns={"Location": "Country", "Road motor vehicles": "number cars"},
+        columns={"Region": "Country", "Road motor vehicles": "number cars"},
         inplace=True,
     )
 


### PR DESCRIPTION
## Changes proposed in this Pull Request
This PR cherry-picks the change in upstream PR #1486 to align `prepare_transport_data_input` with the new structure of the Wikipedia page we fetch data from.

## Checklist

- [ ] I consent to the release of this PR's code under the AGPLv3 license and non-code contributions under CC0-1.0 and CC-BY-4.0.
- [ ] I tested my contribution locally and it seems to work fine.
- [ ] Code and workflow changes are sufficiently documented.
- [ ] Newly introduced dependencies are added to `envs/environment.yaml` and `doc/requirements.txt`.
- [ ] Changes in configuration options are added in all of `config.default.yaml` and `config.tutorial.yaml`.
- [ ] Add a test config or line additions to `test/` (note tests are changing the config.tutorial.yaml)
- [ ] Changes in configuration options are also documented in `doc/configtables/*.csv` and line references are adjusted in `doc/configuration.rst` and `doc/tutorial.rst`.
- [ ] A note for the release notes `doc/release_notes.rst` is amended in the format of previous release notes, including reference to the requested PR.
