### PR TITLE
Fix currency exchange rate averaging to handle limited date ranges

### DIFF
--- a/scripts/_helpers.py
+++ b/scripts/_helpers.py
@@ -1001,6 +1001,7 @@ def get_yearly_currency_exchange_average(
         f"No exchange rate data found for {initial_currency}->{output_currency} in {effective_year}, and no default rate provided."
     )
 
+
 def convert_currency_and_unit(
     cost_dataframe, output_currency: str, default_exchange_rate: float = None
 ):


### PR DESCRIPTION
## Changes proposed in this Pull Request
Fix currency exchange rate averaging to handle limited date ranges for years with incomplete set of data (e.g. 2025 only has data until June 9, so we want to use data until that day, averaging on days until June 9).

## Checklist

- [ ] I consent to the release of this PR's code under the AGPLv3 license and non-code contributions under CC0-1.0 and CC-BY-4.0.
- [ ] I tested my contribution locally and it seems to work fine.
- [ ] Code and workflow changes are sufficiently documented.
- [ ] Newly introduced dependencies are added to `envs/environment.yaml` and `doc/requirements.txt`.
- [ ] Changes in configuration options are added in all of `config.default.yaml` and `config.tutorial.yaml`.
- [ ] Add a test config or line additions to `test/` (note tests are changing the config.tutorial.yaml)
- [ ] Changes in configuration options are also documented in `doc/configtables/*.csv` and line references are adjusted in `doc/configuration.rst` and `doc/tutorial.rst`.
- [ ] A note for the release notes `doc/release_notes.rst` is amended in the format of previous release notes, including reference to the requested PR.
