### PR TITLE
Fix biomass EOP

### DIFF
--- a/scripts/prepare_sector_network.py
+++ b/scripts/prepare_sector_network.py
@@ -977,23 +977,31 @@ def add_biomass(n, costs):
     )
 
     biomass_gen = "biomass EOP"
-    n.madd(
-        "Link",
-        spatial.nodes + " biomass EOP",
-        bus0=spatial.biomass.nodes,
-        bus1=spatial.nodes,
-        # bus2="co2 atmosphere",
-        marginal_cost=costs.at[biomass_gen, "efficiency"]
-        * costs.at[biomass_gen, "VOM"],  # NB: VOM is per MWel
-        # NB: fixed cost is per MWel
-        capital_cost=costs.at[biomass_gen, "efficiency"]
-        * costs.at[biomass_gen, "fixed"],
-        p_nom_extendable=True,
-        carrier=biomass_gen,
-        efficiency=costs.at[biomass_gen, "efficiency"],
-        # efficiency2=costs.at["solid biomass", "CO2 intensity"],
-        lifetime=costs.at[biomass_gen, "lifetime"],
-    )
+    if biomass_gen in snakemake.params.electricity["conventional_carriers"]:
+        n.madd(
+            "Link",
+            spatial.nodes + " biomass EOP",
+            bus0=spatial.biomass.nodes,
+            bus1=spatial.nodes,
+            # bus2="co2 atmosphere",
+            marginal_cost=costs.at[biomass_gen, "efficiency"]
+            * costs.at[biomass_gen, "VOM"],  # NB: VOM is per MWel
+            # NB: fixed cost is per MWel
+            capital_cost=costs.at[biomass_gen, "efficiency"]
+            * costs.at[biomass_gen, "fixed"],
+            p_nom_extendable=(
+                True
+                if biomass_gen
+                in snakemake.params.electricity.get("extendable_carriers", dict()).get(
+                    "Generator", list()
+                )
+                else False
+            ),
+            carrier=biomass_gen,
+            efficiency=costs.at[biomass_gen, "efficiency"],
+            # efficiency2=costs.at["solid biomass", "CO2 intensity"],
+            lifetime=costs.at[biomass_gen, "lifetime"],
+        )
     n.madd(
         "Link",
         spatial.gas.biogas_to_gas,


### PR DESCRIPTION
## Changes proposed in this Pull Request
Good day. This PR makes `biomass EOP` only present if provided in the config. Otherwise it is added by default with `p_nom_extendable: True`. Now, it will be added, if only defined in `conventional_carriers`. It's extendibility is defined in `extendable_carriers`. 

## Checklist

- [x] I consent to the release of this PR's code under the AGPLv3 license and non-code contributions under CC0-1.0 and CC-BY-4.0.
- [x] I tested my contribution locally and it seems to work fine.
- [ ] Code and workflow changes are sufficiently documented.
- [ ] Newly introduced dependencies are added to `envs/environment.yaml` and `doc/requirements.txt`.
- [ ] Changes in configuration options are added in all of `config.default.yaml` and `config.tutorial.yaml`.
- [ ] Add a test config or line additions to `test/` (note tests are changing the config.tutorial.yaml)
- [ ] Changes in configuration options are also documented in `doc/configtables/*.csv` and line references are adjusted in `doc/configuration.rst` and `doc/tutorial.rst`.
- [ ] A note for the release notes `doc/release_notes.rst` is amended in the format of previous release notes, including reference to the requested PR.
