### PR TITLE
Align cost conversion with technology-data reference year

### DIFF
--- a/config.default.yaml
+++ b/config.default.yaml
@@ -367,6 +367,7 @@ costs:
   financial_case: "market" # only used if `country_specific_data: "US"`; can be "market" or "r&d"
   discountrate: [0.071] #, 0.086, 0.111]
   output_currency: "USD"
+  reference_year: 2020 # reference year for output costs
   default_USD_to_EUR: 0.7532 # previously USD2013_to_EUR2013; should be sufficient as current data from 'technology-data` are either in EUR or USD; [EUR/USD] ECB: https://www.ecb.europa.eu/stats/exchange/eurofxref/html/eurofxref-graph-usd.en.html
   rooftop_share: 0.14 # based on the potentials, assuming (0.1 kW/m2 and 10 m2/person)
 

--- a/scripts/_helpers.py
+++ b/scripts/_helpers.py
@@ -1060,6 +1060,7 @@ def prepare_costs(
     fill_values: dict,
     Nyears: float | int = 1,
     default_exchange_rate: float = None,
+    reference_year: int | None = None,
 ):
     # set all asset costs and other parameters
     costs = pd.read_csv(cost_file, index_col=[0, 1]).sort_index()

--- a/scripts/_helpers.py
+++ b/scripts/_helpers.py
@@ -1019,7 +1019,10 @@ def get_yearly_currency_exchange_average(
 
 
 def convert_currency_and_unit(
-    cost_dataframe, output_currency: str, default_exchange_rate: float = None, reference_year: int = 2020
+    cost_dataframe,
+    output_currency: str,
+    default_exchange_rate: float = None,
+    reference_year: int = 2020,
 ):
     """
     Convert all cost values to the specified output_currency using a fixed reference_year.
@@ -1140,7 +1143,7 @@ def prepare_costs(
         costs,
         output_currency,
         default_exchange_rate=config.get("default_exchange_rate"),
-        reference_year=config.get("reference_year", 2020)
+        reference_year=config.get("reference_year", 2020),
     )
 
     # min_count=1 is important to generate NaNs which are then filled by fillna

--- a/scripts/add_electricity.py
+++ b/scripts/add_electricity.py
@@ -18,7 +18,8 @@ Relevant Settings
         version:
         rooftop_share:
         output_currency:
-        dicountrate:
+        reference_year:
+        discountrate:
         emission_prices:
 
     electricity:
@@ -145,7 +146,12 @@ def load_costs(tech_costs, config, elec_config, Nyears=1):
     # correct units to MW and output_currency
     costs.loc[costs.unit.str.contains("/kW"), "value"] *= 1e3
     costs.unit = costs.unit.str.replace("/kW", "/MW")
-    costs = convert_currency_and_unit(costs, config["output_currency"])
+    costs = convert_currency_and_unit(
+        costs,
+        output_currency=config["output_currency"],
+        default_exchange_rate=config.get("default_exchange_rate"),
+        reference_year=config.get("reference_year", 2020),
+    )
 
     # apply filter on financial_case and scenario, if they are contained in the cost dataframe
     wished_cost_scenario = config["cost_scenario"]

--- a/scripts/add_existing_baseyear.py
+++ b/scripts/add_existing_baseyear.py
@@ -617,6 +617,7 @@ if __name__ == "__main__":
         snakemake.params.costs["fill_values"],
         Nyears,
         snakemake.params.costs["default_USD_to_EUR"],
+        reference_year=snakemake.config["costs"].get("reference_year", 2020),
     )
 
     grouping_years_power = snakemake.params.existing_capacities["grouping_years_power"]

--- a/scripts/add_export.py
+++ b/scripts/add_export.py
@@ -238,6 +238,7 @@ if __name__ == "__main__":
         snakemake.params.costs["fill_values"],
         Nyears,
         snakemake.params.costs["default_USD_to_EUR"],
+        reference_year=snakemake.config["costs"].get("reference_year", 2020),
     )
 
     # get hydrogen export buses/ports

--- a/scripts/prepare_sector_network.py
+++ b/scripts/prepare_sector_network.py
@@ -3125,6 +3125,7 @@ if __name__ == "__main__":
         snakemake.params.costs["fill_values"],
         Nyears,
         snakemake.params.costs["default_USD_to_EUR"],
+        reference_year=snakemake.config["costs"].get("reference_year", 2020),
     )
 
     # Define spatial for biomass and co2. They require the same spatial definition


### PR DESCRIPTION
## Changes proposed in this Pull Request
see this [PR](https://github.com/pypsa-meets-earth/pypsa-earth/pull/1604) in the upstream.

## Checklist

- [ ] I consent to the release of this PR's code under the AGPLv3 license and non-code contributions under CC0-1.0 and CC-BY-4.0.
- [ ] I tested my contribution locally and it seems to work fine.
- [ ] Code and workflow changes are sufficiently documented including ammending docstrings for meaningful functions.
- [ ] Newly introduced dependencies are added to `envs/environment.yaml` and `doc/requirements.txt`.
- [ ] Changes in configuration options are added in all of `config.default.yaml` and `config.tutorial.yaml`.
- [ ] Add a test config or line additions to `test/` (note tests are changing the config.tutorial.yaml)
- [ ] Changes in configuration options are also documented in `doc/configtables/*.csv` and line references are adjusted in `doc/configuration.rst` and `doc/tutorial.rst`.
- [ ] Archives of the uploaded data do not have an enclosing folder and archive names correspond to the conventions of `configs/bundle_config.yaml`.
- [ ] A note for the release notes `doc/release_notes.rst` is amended in the format of previous release notes, including reference to the requested PR.
