### PR TITLE
use carbondioxide-input for FT as value to compute FT efficiency2

### DIFF
--- a/scripts/prepare_sector_network.py
+++ b/scripts/prepare_sector_network.py
@@ -214,7 +214,7 @@ def H2_liquid_fossil_conversions(n, costs):
         * costs.at[
             "Fischer-Tropsch", "efficiency"
         ],  # Use efficiency to convert from EUR/MW_FT/a to EUR/MW_H2/a
-        efficiency2=-costs.at["oil", "CO2 intensity"]
+        efficiency2=-costs.at["Fischer-Tropsch", "carbondioxide-input"]
         * costs.at["Fischer-Tropsch", "efficiency"],
         efficiency3=-costs.at["Fischer-Tropsch", "electricity-input"]
         / costs.at["Fischer-Tropsch", "hydrogen-input"],


### PR DESCRIPTION
## Changes proposed in this Pull Request
Following a comment by Yuanrong, this PR assigns a higher CO2 input to Fischer-Tropsch with respect to the one computed using oil CO2 intensity.

## Checklist

- [ ] I consent to the release of this PR's code under the AGPLv3 license and non-code contributions under CC0-1.0 and CC-BY-4.0.
- [ ] I tested my contribution locally and it seems to work fine.
- [ ] Code and workflow changes are sufficiently documented including ammending docstrings for meaningful functions.
- [ ] Newly introduced dependencies are added to `envs/environment.yaml` and `doc/requirements.txt`.
- [ ] Changes in configuration options are added in all of `config.default.yaml` and `config.tutorial.yaml`.
- [ ] Add a test config or line additions to `test/` (note tests are changing the config.tutorial.yaml)
- [ ] Changes in configuration options are also documented in `doc/configtables/*.csv` and line references are adjusted in `doc/configuration.rst` and `doc/tutorial.rst`.
- [ ] Archives of the uploaded data do not have an enclosing folder and archive names correspond to the conventions of `configs/bundle_config.yaml`.
- [ ] A note for the release notes `doc/release_notes.rst` is amended in the format of previous release notes, including reference to the requested PR.
