### PR TITLE
Patch solve_network for HiPO solver adoption

### DIFF
--- a/scripts/solve_network.py
+++ b/scripts/solve_network.py
@@ -1138,6 +1138,7 @@ def solve_network(n, config, solving, **kwargs):
         os.environ["PATH"] = f"{highs_bin}:{os.environ['PATH']}"
 
         import shutil
+
         logger.info(f"Using highs from: {shutil.which('highs')}")
 
     elif io_api:

--- a/scripts/solve_network.py
+++ b/scripts/solve_network.py
@@ -1120,7 +1120,29 @@ def solve_network(n, config, solving, **kwargs):
     kwargs["solver_options"] = (
         solving["solver_options"][set_of_options] if set_of_options else {}
     )
-    kwargs["solver_name"] = solving["solver"]["name"]
+    solver_name = solving["solver"]["name"]
+    kwargs["solver_name"] = solver_name
+
+    io_api = solving["solver"].get("io_api")
+
+    if solver_name == "highs":
+        kwargs["io_api"] = io_api or "lp"
+
+        project_root = Path.cwd()
+        highs_bin = (
+            project_root
+            / "tools"
+            / "highs-1.14.0-x86_64-linux-gnu-static-apache"
+            / "bin"
+        )
+        os.environ["PATH"] = f"{highs_bin}:{os.environ['PATH']}"
+
+        import shutil
+        logger.info(f"Using highs from: {shutil.which('highs')}")
+
+    elif io_api:
+        kwargs["io_api"] = io_api
+
     kwargs["assign_all_duals"] = True
     kwargs["extra_functionality"] = extra_functionality
 


### PR DESCRIPTION
## Changes proposed in this Pull Request
This PR proposes a patch to adopt HiGHS HiPO as solver for model runs (in the power-only model guarantees >10X speedup wrt default IPX solver)

## Checklist

- [ ] I consent to the release of this PR's code under the AGPLv3 license and non-code contributions under CC0-1.0 and CC-BY-4.0.
- [ ] I tested my contribution locally and it seems to work fine.
- [ ] Code and workflow changes are sufficiently documented, including updates to docstrings for meaningful functions.
- [ ] Newly introduced dependencies are added to `envs/environment.yaml` and `doc/requirements.txt`.
- [ ] Changes in configuration options are added in all of `config.default.yaml` and `config.tutorial.yaml`.
- [ ] Add a test config or line additions to `test/` (note tests are changing the config.tutorial.yaml)
- [ ] Changes in configuration options are also documented in `doc/configtables/*.csv` and line references are adjusted in `doc/user-guide/configuration.md` and `doc/tutorials/electricity-model.md`.
- [ ] If config sections were added, renamed, or removed, update `doc/assets/scripts/extract_config_snippets.py` accordingly.
- [ ] Archives of the uploaded data do not have an enclosing folder and archive names correspond to the conventions of `configs/bundle_config.yaml`.
- [ ] A note for the release notes `doc/release-notes.md` is amended in the format of previous release notes, including reference to the requested PR.
