### PR TITLE
Add existing rooftop solar integration using CER dataset (Australia)

### DIFF
--- a/Snakefile
+++ b/Snakefile
@@ -1240,6 +1240,10 @@ rule prepare_sector_network:
                 for country in config["countries"]
             },
         ),
+        rooftop_solar_existing=branch(
+            config["sector"]["solar_rooftop"].get("existing", False),
+            "resources/" + RDIR + "rooftop_solar_existing.csv",
+        ),
         network=RESDIR
         + "prenetworks/elec_s{simpl}_{clusters}_ec_l{ll}_{opts}_{sopts}_{planning_horizons}_{discountrate}_{demand}_presec.nc",
         costs="resources/" + RDIR + "costs_{planning_horizons}_sec.csv",

--- a/Snakefile
+++ b/Snakefile
@@ -1242,7 +1242,9 @@ rule prepare_sector_network:
         ),
         rooftop_solar_existing=branch(
             config["sector"]["solar_rooftop"].get("existing", False),
-            "resources/" + RDIR + "rooftop_solar_existing.csv",
+            "resources/"
+            + RDIR
+            + "rooftop_solar_existing_elec_s{simpl}_{clusters}_{planning_horizons}.csv",
         ),
         network=RESDIR
         + "prenetworks/elec_s{simpl}_{clusters}_ec_l{ll}_{opts}_{sopts}_{planning_horizons}_{discountrate}_{demand}_presec.nc",

--- a/Snakefile
+++ b/Snakefile
@@ -1246,6 +1246,7 @@ rule prepare_sector_network:
             + RDIR
             + "rooftop_solar_existing_elec_s{simpl}_{clusters}_{planning_horizons}.csv",
         ),
+        solar_profile="resources/" + RDIR + "renewable_profiles/profile_solar.nc",
         network=RESDIR
         + "prenetworks/elec_s{simpl}_{clusters}_ec_l{ll}_{opts}_{sopts}_{planning_horizons}_{discountrate}_{demand}_presec.nc",
         costs="resources/" + RDIR + "costs_{planning_horizons}_sec.csv",

--- a/scripts/prepare_sector_network.py
+++ b/scripts/prepare_sector_network.py
@@ -3038,6 +3038,7 @@ def add_co2_budget(n, co2_budget, investment_year, elec_opts):
 def add_existing_rooftop_solar(
     n: pypsa.Network,
     rooftop_existing_fn: str,
+    solar_profile_fn: str,
 ) -> None:
     """
     Add existing rooftop solar generators on low-voltage buses.
@@ -3048,8 +3049,11 @@ def add_existing_rooftop_solar(
         Sector network.
     rooftop_existing_fn : str
         CSV file with columns ['node', 'p_nom'], where p_nom is in MW.
+    solar_profile_fn : str
+        NetCDF renewable profile file for utility solar.
     """
     logger.info("Adding existing rooftop solar from %s", rooftop_existing_fn)
+    logger.info("Using solar availability profile from %s", solar_profile_fn)
 
     rooftop = pd.read_csv(rooftop_existing_fn)
 
@@ -3083,43 +3087,31 @@ def add_existing_rooftop_solar(
             f"Missing examples: {list(missing_lv_buses[:10])}"
         )
 
-    solar_gens = n.generators[n.generators.carrier == "solar"].copy()
-    if solar_gens.empty:
+    profile_ds = xr.open_dataset(solar_profile_fn)
+
+    if "profile" not in profile_ds:
         raise ValueError(
-            "No 'solar' generators found in the network. "
-            "Cannot infer rooftop solar availability profiles."
+            "Variable 'profile' not found in solar profile file."
         )
 
-    solar_p_max_pu = n.generators_t.p_max_pu.loc[:, solar_gens.index]
+    solar_profile = profile_ds["profile"].to_pandas()
 
-    profile_names = []
-    fallback_counter = 0
+    if isinstance(solar_profile, pd.Series):
+        solar_profile = solar_profile.to_frame()
 
-    for node in rooftop["node"]:
-        candidate_name = f"{node} solar"
+    # Ensure columns are strings
+    solar_profile.columns = solar_profile.columns.astype(str)
 
-        if candidate_name in solar_gens.index:
-            profile_names.append(candidate_name)
-            continue
-
-        same_bus = solar_gens.index[solar_gens.bus == node]
-        if len(same_bus) > 0:
-            profile_names.append(same_bus[0])
-            fallback_counter += 1
-            continue
-
-        profile_names.append(solar_gens.index[0])
-        fallback_counter += 1
-
-    if fallback_counter > 0:
-        logger.warning(
-            "Used fallback solar profiles for %d rooftop nodes because "
-            "matching '{node} solar' generators were not found.",
-            fallback_counter,
+    missing_nodes = rooftop.loc[~rooftop["node"].isin(solar_profile.columns), "node"].unique()
+    if len(missing_nodes) > 0:
+        raise ValueError(
+            "Some rooftop nodes do not have a matching solar profile in "
+            f"{solar_profile_fn}. Missing examples: {list(missing_nodes[:10])}"
         )
 
-    profile_names = pd.Index(profile_names, index=rooftop.index)
     gen_names = rooftop["node"] + " rooftop existing"
+    p_max_pu = solar_profile.loc[:, rooftop["node"]].copy()
+    p_max_pu.columns = gen_names.values
 
     n.madd(
         "Generator",
@@ -3128,10 +3120,10 @@ def add_existing_rooftop_solar(
         carrier="solar rooftop",
         p_nom=rooftop["p_nom"].values,
         p_nom_extendable=False,
-        marginal_cost=n.generators.loc[profile_names, "marginal_cost"].values,
-        capital_cost=costs.at["solar-rooftop", "fixed"],
-        efficiency=n.generators.loc[profile_names, "efficiency"].values,
-        p_max_pu=solar_p_max_pu[profile_names].set_axis(gen_names, axis=1),
+        marginal_cost=0.0,
+        capital_cost=0.0,
+        efficiency=1.0,
+        p_max_pu=p_max_pu,
         lifetime=costs.at["solar-rooftop", "lifetime"],
     )
 
@@ -3486,6 +3478,7 @@ if __name__ == "__main__":
             add_existing_rooftop_solar(
                 n,
                 rooftop_existing_fn=snakemake.input.rooftop_solar_existing,
+                solar_profile_fn=snakemake.input.solar_profile,
             )
 
     sopts = snakemake.wildcards.sopts.split("-")

--- a/scripts/prepare_sector_network.py
+++ b/scripts/prepare_sector_network.py
@@ -3050,7 +3050,7 @@ def add_existing_rooftop_solar(
     rooftop_existing_fn : str
         CSV file with columns ['node', 'p_nom'], where p_nom is in MW.
     solar_profile_fn : str
-        NetCDF renewable profile file for utility solar.
+        NetCDF renewable profile file for solar availability.
     """
     logger.info("Adding existing rooftop solar from %s", rooftop_existing_fn)
     logger.info("Using solar availability profile from %s", solar_profile_fn)
@@ -3090,68 +3090,31 @@ def add_existing_rooftop_solar(
     profile_ds = xr.open_dataset(solar_profile_fn)
 
     if "profile" not in profile_ds:
-        raise ValueError(
-            "Variable 'profile' not found in solar profile file."
-        )
+        raise ValueError("Variable 'profile' not found in solar profile file.")
 
     solar_profile = profile_ds["profile"].to_pandas()
 
     if isinstance(solar_profile, pd.Series):
         solar_profile = solar_profile.to_frame()
 
-    solar_profile.columns = solar_profile.columns.astype(str)
+    if solar_profile.empty:
+        raise ValueError("Solar profile file contains no usable profile data.")
 
-    # Case 1: direct match available
-    available_nodes = pd.Index(solar_profile.columns)
-    rooftop["profile_node"] = rooftop["node"]
+    # Use a single aggregate solar profile for all existing rooftop generators.
+    # This avoids assuming that profile_solar.nc columns match PyPSA bus names.
+    aggregate_profile = solar_profile.mean(axis=1)
 
-    missing_mask = ~rooftop["profile_node"].isin(available_nodes)
+    if aggregate_profile.isna().all():
+        raise ValueError("Aggregate solar profile is entirely NaN.")
 
-    if missing_mask.any():
-        logger.warning(
-            "%d rooftop nodes have no direct solar profile match. "
-            "They will be mapped to the nearest node with an available solar profile.",
-            int(missing_mask.sum()),
-        )
-
-        profile_buses = n.buses.loc[n.buses.index.intersection(available_nodes)].copy()
-        profile_buses = profile_buses.dropna(subset=["x", "y"])
-
-        if profile_buses.empty:
-            raise ValueError(
-                "No buses in the network match the solar profile columns. "
-                "Cannot assign rooftop solar profiles."
-            )
-
-        rooftop_missing = rooftop.loc[missing_mask].copy()
-        rooftop_missing_buses = n.buses.loc[
-            rooftop_missing["node"].values
-        ].dropna(subset=["x", "y"])
-
-        if rooftop_missing_buses.empty:
-            raise ValueError(
-                "Missing rooftop nodes do not have valid coordinates in n.buses."
-            )
-
-        tree = cKDTree(profile_buses[["x", "y"]].to_numpy())
-        _, idx = tree.query(rooftop_missing_buses[["x", "y"]].to_numpy(), k=1)
-
-        nearest_profile_nodes = profile_buses.index.to_numpy()[idx]
-
-        rooftop.loc[missing_mask, "profile_node"] = nearest_profile_nodes
-
-        example_map = (
-            rooftop.loc[missing_mask, ["node", "profile_node"]]
-            .drop_duplicates()
-            .head(10)
-            .to_dict(orient="records")
-        )
-        logger.info("Example nearest rooftop profile mapping: %s", example_map)
+    aggregate_profile = aggregate_profile.fillna(0.0)
 
     gen_names = rooftop["node"] + " rooftop existing"
 
-    p_max_pu = solar_profile.loc[:, rooftop["profile_node"]].copy()
-    p_max_pu.columns = gen_names.values
+    p_max_pu = pd.concat(
+        [aggregate_profile.rename(name) for name in gen_names],
+        axis=1,
+    )
 
     n.madd(
         "Generator",

--- a/scripts/prepare_sector_network.py
+++ b/scripts/prepare_sector_network.py
@@ -3474,9 +3474,9 @@ if __name__ == "__main__":
         add_electricity_distribution_grid(n, costs)
 
         if (
-                options.get("solar_rooftop", False)
-                and isinstance(options["solar_rooftop"], dict)
-                and options["solar_rooftop"].get("existing", False)
+            options.get("solar_rooftop", False)
+            and isinstance(options["solar_rooftop"], dict)
+            and options["solar_rooftop"].get("existing", False)
         ):
             add_existing_rooftop_solar(
                 n,

--- a/scripts/prepare_sector_network.py
+++ b/scripts/prepare_sector_network.py
@@ -3099,18 +3099,58 @@ def add_existing_rooftop_solar(
     if isinstance(solar_profile, pd.Series):
         solar_profile = solar_profile.to_frame()
 
-    # Ensure columns are strings
     solar_profile.columns = solar_profile.columns.astype(str)
 
-    missing_nodes = rooftop.loc[~rooftop["node"].isin(solar_profile.columns), "node"].unique()
-    if len(missing_nodes) > 0:
-        raise ValueError(
-            "Some rooftop nodes do not have a matching solar profile in "
-            f"{solar_profile_fn}. Missing examples: {list(missing_nodes[:10])}"
+    # Case 1: direct match available
+    available_nodes = pd.Index(solar_profile.columns)
+    rooftop["profile_node"] = rooftop["node"]
+
+    missing_mask = ~rooftop["profile_node"].isin(available_nodes)
+
+    if missing_mask.any():
+        logger.warning(
+            "%d rooftop nodes have no direct solar profile match. "
+            "They will be mapped to the nearest node with an available solar profile.",
+            int(missing_mask.sum()),
         )
 
+        profile_buses = n.buses.loc[n.buses.index.intersection(available_nodes)].copy()
+        profile_buses = profile_buses.dropna(subset=["x", "y"])
+
+        if profile_buses.empty:
+            raise ValueError(
+                "No buses in the network match the solar profile columns. "
+                "Cannot assign rooftop solar profiles."
+            )
+
+        rooftop_missing = rooftop.loc[missing_mask].copy()
+        rooftop_missing_buses = n.buses.loc[
+            rooftop_missing["node"].values
+        ].dropna(subset=["x", "y"])
+
+        if rooftop_missing_buses.empty:
+            raise ValueError(
+                "Missing rooftop nodes do not have valid coordinates in n.buses."
+            )
+
+        tree = cKDTree(profile_buses[["x", "y"]].to_numpy())
+        _, idx = tree.query(rooftop_missing_buses[["x", "y"]].to_numpy(), k=1)
+
+        nearest_profile_nodes = profile_buses.index.to_numpy()[idx]
+
+        rooftop.loc[missing_mask, "profile_node"] = nearest_profile_nodes
+
+        example_map = (
+            rooftop.loc[missing_mask, ["node", "profile_node"]]
+            .drop_duplicates()
+            .head(10)
+            .to_dict(orient="records")
+        )
+        logger.info("Example nearest rooftop profile mapping: %s", example_map)
+
     gen_names = rooftop["node"] + " rooftop existing"
-    p_max_pu = solar_profile.loc[:, rooftop["node"]].copy()
+
+    p_max_pu = solar_profile.loc[:, rooftop["profile_node"]].copy()
     p_max_pu.columns = gen_names.values
 
     n.madd(

--- a/scripts/prepare_sector_network.py
+++ b/scripts/prepare_sector_network.py
@@ -3066,12 +3066,16 @@ def add_existing_rooftop_solar(
     rooftop = rooftop[rooftop["p_nom"] > 0]
 
     if rooftop.empty:
-        logger.warning("No positive rooftop solar capacities found in %s", rooftop_existing_fn)
+        logger.warning(
+            "No positive rooftop solar capacities found in %s",
+            rooftop_existing_fn,
+        )
         return
 
-    # Require low-voltage buses to exist already
     rooftop["lv_bus"] = rooftop["node"] + " low voltage"
-    missing_lv_buses = rooftop.loc[~rooftop["lv_bus"].isin(n.buses.index), "lv_bus"].unique()
+    missing_lv_buses = rooftop.loc[
+        ~rooftop["lv_bus"].isin(n.buses.index), "lv_bus"
+    ].unique()
     if len(missing_lv_buses) > 0:
         raise ValueError(
             "Some rooftop low-voltage buses do not exist. "
@@ -3079,16 +3083,42 @@ def add_existing_rooftop_solar(
             f"Missing examples: {list(missing_lv_buses[:10])}"
         )
 
-    # Use the corresponding utility-scale solar profile where available
-    solar_profile_index = rooftop["node"] + " solar"
-    missing_profiles = solar_profile_index[~solar_profile_index.isin(n.generators.index)]
-
-    if len(missing_profiles) > 0:
+    solar_gens = n.generators[n.generators.carrier == "solar"].copy()
+    if solar_gens.empty:
         raise ValueError(
-            "Some rooftop nodes do not have a matching 'node solar' generator profile. "
-            f"Missing examples: {list(missing_profiles[:10])}"
+            "No 'solar' generators found in the network. "
+            "Cannot infer rooftop solar availability profiles."
         )
 
+    solar_p_max_pu = n.generators_t.p_max_pu.loc[:, solar_gens.index]
+
+    profile_names = []
+    fallback_counter = 0
+
+    for node in rooftop["node"]:
+        candidate_name = f"{node} solar"
+
+        if candidate_name in solar_gens.index:
+            profile_names.append(candidate_name)
+            continue
+
+        same_bus = solar_gens.index[solar_gens.bus == node]
+        if len(same_bus) > 0:
+            profile_names.append(same_bus[0])
+            fallback_counter += 1
+            continue
+
+        profile_names.append(solar_gens.index[0])
+        fallback_counter += 1
+
+    if fallback_counter > 0:
+        logger.warning(
+            "Used fallback solar profiles for %d rooftop nodes because "
+            "matching '{node} solar' generators were not found.",
+            fallback_counter,
+        )
+
+    profile_names = pd.Index(profile_names, index=rooftop.index)
     gen_names = rooftop["node"] + " rooftop existing"
 
     n.madd(
@@ -3098,10 +3128,10 @@ def add_existing_rooftop_solar(
         carrier="solar rooftop",
         p_nom=rooftop["p_nom"].values,
         p_nom_extendable=False,
-        marginal_cost=n.generators.loc[solar_profile_index, "marginal_cost"].values,
-        capital_cost=0,
-        efficiency=n.generators.loc[solar_profile_index, "efficiency"].values,
-        p_max_pu=n.generators_t.p_max_pu[solar_profile_index].copy(),
+        marginal_cost=n.generators.loc[profile_names, "marginal_cost"].values,
+        capital_cost=costs.at["solar-rooftop", "fixed"],
+        efficiency=n.generators.loc[profile_names, "efficiency"].values,
+        p_max_pu=solar_p_max_pu[profile_names].set_axis(gen_names, axis=1),
         lifetime=costs.at["solar-rooftop", "lifetime"],
     )
 

--- a/scripts/prepare_sector_network.py
+++ b/scripts/prepare_sector_network.py
@@ -2880,13 +2880,15 @@ def add_electricity_distribution_grid(n, costs):
     mchp = n.links.index[n.links.carrier.str.contains("micro gas")]
     n.links.loc[mchp, "bus1"] += " low voltage"
 
+    enable_solar_rooftop = False
+    solar_opts = {}
+
     if options.get("solar_rooftop", False):
         if isinstance(options["solar_rooftop"], dict):
             enable_solar_rooftop = options["solar_rooftop"]["enable"]
             solar_opts = options["solar_rooftop"]
         else:
             enable_solar_rooftop = True
-            solar_opts = {}
 
     if enable_solar_rooftop:
         # set existing solar to cost of utility cost rather the 50-50 rooftop-utility
@@ -3031,6 +3033,83 @@ def add_co2_budget(n, co2_budget, investment_year, elec_opts):
     )
 
     add_co2limit(n, annual_emissions, Nyears)
+
+
+def add_existing_rooftop_solar(
+    n: pypsa.Network,
+    rooftop_existing_fn: str,
+) -> None:
+    """
+    Add existing rooftop solar generators on low-voltage buses.
+
+    Parameters
+    ----------
+    n : pypsa.Network
+        Sector network.
+    rooftop_existing_fn : str
+        CSV file with columns ['node', 'p_nom'], where p_nom is in MW.
+    """
+    logger.info("Adding existing rooftop solar from %s", rooftop_existing_fn)
+
+    rooftop = pd.read_csv(rooftop_existing_fn)
+
+    required_cols = {"node", "p_nom"}
+    missing_cols = required_cols - set(rooftop.columns)
+    if missing_cols:
+        raise ValueError(
+            f"Missing required columns in rooftop existing file: {missing_cols}"
+        )
+
+    rooftop = rooftop.copy()
+    rooftop["node"] = rooftop["node"].astype(str)
+    rooftop["p_nom"] = pd.to_numeric(rooftop["p_nom"], errors="coerce").fillna(0.0)
+    rooftop = rooftop[rooftop["p_nom"] > 0]
+
+    if rooftop.empty:
+        logger.warning("No positive rooftop solar capacities found in %s", rooftop_existing_fn)
+        return
+
+    # Require low-voltage buses to exist already
+    rooftop["lv_bus"] = rooftop["node"] + " low voltage"
+    missing_lv_buses = rooftop.loc[~rooftop["lv_bus"].isin(n.buses.index), "lv_bus"].unique()
+    if len(missing_lv_buses) > 0:
+        raise ValueError(
+            "Some rooftop low-voltage buses do not exist. "
+            "Make sure add_electricity_distribution_grid() is called first. "
+            f"Missing examples: {list(missing_lv_buses[:10])}"
+        )
+
+    # Use the corresponding utility-scale solar profile where available
+    solar_profile_index = rooftop["node"] + " solar"
+    missing_profiles = solar_profile_index[~solar_profile_index.isin(n.generators.index)]
+
+    if len(missing_profiles) > 0:
+        raise ValueError(
+            "Some rooftop nodes do not have a matching 'node solar' generator profile. "
+            f"Missing examples: {list(missing_profiles[:10])}"
+        )
+
+    gen_names = rooftop["node"] + " rooftop existing"
+
+    n.madd(
+        "Generator",
+        gen_names,
+        bus=rooftop["lv_bus"].values,
+        carrier="solar rooftop",
+        p_nom=rooftop["p_nom"].values,
+        p_nom_extendable=False,
+        marginal_cost=n.generators.loc[solar_profile_index, "marginal_cost"].values,
+        capital_cost=0,
+        efficiency=n.generators.loc[solar_profile_index, "efficiency"].values,
+        p_max_pu=n.generators_t.p_max_pu[solar_profile_index].copy(),
+        lifetime=costs.at["solar-rooftop", "lifetime"],
+    )
+
+    logger.info(
+        "Added %d existing rooftop solar generators with %.3f GW total capacity",
+        len(rooftop),
+        rooftop["p_nom"].sum() / 1e3,
+    )
 
 
 def add_custom_water_cost(n):
@@ -3368,6 +3447,16 @@ if __name__ == "__main__":
 
     if options.get("electricity_distribution_grid", False):
         add_electricity_distribution_grid(n, costs)
+
+        if (
+                options.get("solar_rooftop", False)
+                and isinstance(options["solar_rooftop"], dict)
+                and options["solar_rooftop"].get("existing", False)
+        ):
+            add_existing_rooftop_solar(
+                n,
+                rooftop_existing_fn=snakemake.input.rooftop_solar_existing,
+            )
 
     sopts = snakemake.wildcards.sopts.split("-")
 


### PR DESCRIPTION
## Changes proposed in this Pull Request

This PR introduces support for **existing rooftop solar capacity** based on the Australian CER (Clean Energy Regulator) dataset and integrates it into the sector network as **fixed (non-extendable) generators** at the low-voltage level.

The implementation:
- represents distributed rooftop PV explicitly
- keeps it separate from utility-scale solar
- avoids interference with existing renewable capacity estimation

### Integration in `prepare_sector_network`

A new function is introduced:

```python
add_existing_rooftop_solar(...)
```

This function:
- reads rooftop capacity per node,
- assigns generators to **low-voltage buses** (`node + " low voltage"`),
- creates generators with:
  - `carrier = "solar rooftop"`
  - `p_nom_extendable = False`
  - `p_nom = fixed existing capacity`

The renewable profile file (`profile_solar.nc`) is **not indexed by clustered bus names**, so direct mapping is not possible.

To ensure robustness:
- a **single aggregate solar profile** (mean over all solar profiles) is used,
- this profile is assigned to all rooftop generators.

This avoids failures due to missing spatial matches.

## Validation

Rooftop generators correctly created:
  - connected to low-voltage buses
  - non-extendable
  - `p_nom_opt = p_nom`
- total installed capacity matches input dataset
- no interference with solar utility

## Limitations

- Uses a single aggregate solar profile, derived as the mean of all available solar profiles in `profile_solar.nc` (no spatial differentiation of rooftop generation)
- Assumes LV buses exist (`add_electricity_distribution_grid`)
- Assumes consistent node naming

## Checklist

- [ ] I consent to the release of this PR's code under the AGPLv3 license and non-code contributions under CC0-1.0 and CC-BY-4.0.
- [ ] I tested my contribution locally and it seems to work fine.
- [ ] Code and workflow changes are sufficiently documented, including updates to docstrings for meaningful functions.
- [ ] Newly introduced dependencies are added to `envs/environment.yaml` and `doc/requirements.txt`.
- [ ] Changes in configuration options are added in all of `config.default.yaml` and `config.tutorial.yaml`.
- [ ] Add a test config or line additions to `test/` (note tests are changing the config.tutorial.yaml)
- [ ] Changes in configuration options are also documented in `doc/configtables/*.csv` and line references are adjusted in `doc/user-guide/configuration.md` and `doc/tutorials/electricity-model.md`.
- [ ] If config sections were added, renamed, or removed, update `doc/assets/scripts/extract_config_snippets.py` accordingly.
- [ ] Archives of the uploaded data do not have an enclosing folder and archive names correspond to the conventions of `configs/bundle_config.yaml`.
- [ ] A note for the release notes `doc/release-notes.md` is amended in the format of previous release notes, including reference to the requested PR.
