### PR TITLE
Fix existing rooftop solar integration in prepare_sector_network

### DIFF
--- a/scripts/prepare_sector_network.py
+++ b/scripts/prepare_sector_network.py
@@ -3114,7 +3114,12 @@ def add_existing_rooftop_solar(
     if aggregate_profile.isna().all():
         raise ValueError("Aggregate solar profile is entirely NaN.")
 
-    aggregate_profile = aggregate_profile.fillna(0.0)
+    aggregate_profile = (
+        aggregate_profile
+        .reindex(n.snapshots, method="nearest")
+        .fillna(0.0)
+        .clip(lower=0.0, upper=1.0)
+    )
 
     gen_names = rooftop["node"] + " rooftop existing"
 
@@ -3123,12 +3128,14 @@ def add_existing_rooftop_solar(
         axis=1,
     )
 
-    n.madd(
+    n.add(
         "Generator",
-        gen_names,
+        name=gen_names,
         bus=rooftop["lv_bus"].values,
         carrier="solar rooftop",
         p_nom=rooftop["p_nom"].values,
+        p_nom_min=rooftop["p_nom"].values,
+        p_nom_max=rooftop["p_nom"].values,
         p_nom_extendable=False,
         marginal_cost=0.0,
         capital_cost=0.0,
@@ -3136,6 +3143,16 @@ def add_existing_rooftop_solar(
         p_max_pu=p_max_pu,
         lifetime=costs.at["solar-rooftop", "lifetime"],
     )
+
+    added_capacity = n.generators.loc[gen_names, "p_nom"].sum()
+    expected_capacity = rooftop["p_nom"].sum()
+
+    if abs(added_capacity - expected_capacity) > 1e-6:
+        raise ValueError(
+            "Existing rooftop solar p_nom was not added correctly. "
+            f"Expected {expected_capacity:.3f} MW, "
+            f"got {added_capacity:.3f} MW."
+        )
 
     logger.info(
         "Added %d existing rooftop solar generators with %.3f GW total capacity",
@@ -3482,16 +3499,17 @@ if __name__ == "__main__":
 
     if options.get("enable_electricity_connection_cost", False):
         add_electricity_grid_connection(n, costs)
-        if (
+
+    if (
             options.get("solar_rooftop", False)
             and isinstance(options["solar_rooftop"], dict)
             and options["solar_rooftop"].get("existing", False)
-        ):
-            add_existing_rooftop_solar(
-                n,
-                rooftop_existing_fn=snakemake.input.rooftop_solar_existing,
-                solar_profile_fn=snakemake.input.solar_profile,
-            )
+    ):
+        add_existing_rooftop_solar(
+            n,
+            rooftop_existing_fn=snakemake.input.rooftop_solar_existing,
+            solar_profile_fn=snakemake.input.solar_profile,
+        )
 
     sopts = snakemake.wildcards.sopts.split("-")
 

--- a/scripts/prepare_sector_network.py
+++ b/scripts/prepare_sector_network.py
@@ -3115,8 +3115,7 @@ def add_existing_rooftop_solar(
         raise ValueError("Aggregate solar profile is entirely NaN.")
 
     aggregate_profile = (
-        aggregate_profile
-        .reindex(n.snapshots, method="nearest")
+        aggregate_profile.reindex(n.snapshots, method="nearest")
         .fillna(0.0)
         .clip(lower=0.0, upper=1.0)
     )
@@ -3501,9 +3500,9 @@ if __name__ == "__main__":
         add_electricity_grid_connection(n, costs)
 
     if (
-            options.get("solar_rooftop", False)
-            and isinstance(options["solar_rooftop"], dict)
-            and options["solar_rooftop"].get("existing", False)
+        options.get("solar_rooftop", False)
+        and isinstance(options["solar_rooftop"], dict)
+        and options["solar_rooftop"].get("existing", False)
     ):
         add_existing_rooftop_solar(
             n,


### PR DESCRIPTION
## Changes proposed in this Pull Request

This PR fixes the integration of existing rooftop solar capacities after the PyPSA 1.x update.

## Changes

- decoupled `add_existing_rooftop_solar()` from `enable_electricity_connection_cost`
- fixed existing rooftop solar integration for PyPSA 1.x by replacing deprecated `n.madd()` usage
- added consistency checks for:
  - fixed `p_nom`
  - `p_nom_min`
  - `p_nom_max`
  - non-extendable behaviour
  - `p_max_pu` alignment with network snapshots
- fixed rooftop solar profile alignment with network snapshots
- ensured existing rooftop solar generators are added on low-voltage buses
- clarified separation between:
  - existing rooftop solar capacities
  - expandable rooftop solar potential

## Checklist

- [ ] I consent to the release of this PR's code under the AGPLv3 license and non-code contributions under CC0-1.0 and CC-BY-4.0.
- [ ] I tested my contribution locally and it seems to work fine.
- [ ] Code and workflow changes are sufficiently documented, including updates to docstrings for meaningful functions.
- [ ] Newly introduced dependencies are added to `envs/environment.yaml` and `doc/requirements.txt`.
- [ ] Changes in configuration options are added in all of `config.default.yaml` and `config.tutorial.yaml`.
- [ ] Add a test config or line additions to `test/` (note tests are changing the config.tutorial.yaml)
- [ ] Changes in configuration options are also documented in `doc/configtables/*.csv` and line references are adjusted in `doc/user-guide/configuration.md` and `doc/tutorials/electricity-model.md`.
- [ ] If config sections were added, renamed, or removed, update `doc/assets/scripts/extract_config_snippets.py` accordingly.
- [ ] Archives of the uploaded data do not have an enclosing folder and archive names correspond to the conventions of `configs/bundle_config.yaml`.
- [ ] A note for the release notes `doc/release-notes.md` is amended in the format of previous release notes, including reference to the requested PR.
